### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "Dexie",
+  "version": "0.9.8",
+  "description": "Minimalistic IndexedDB API with bullet proof transactions",
+  "main": "src/Dexie.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfahlander/Dexie.js.git"
+  },
+  "keywords": [
+    "indexeddb",
+    "browser",
+    "database"
+  ],
+  "author": "David Fahlander",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/dfahlander/Dexie.js/issues"
+  },
+  "homepage": "https://github.com/dfahlander/Dexie.js"
+}


### PR DESCRIPTION
Thank you for providing support for using Dexie as a CommonJS module. This adds a package.json file to the root so that Dexie can be installed with npm.

I made the version 0.9.8 instead of 0.9.8.1 because node only allows [semvar](https://www.npmjs.org/doc/package.json.html#version) version numbers in the format `x.y.z`.
