### PR TITLE
Don't try to modify frozen objects.

### DIFF
--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -2904,6 +2904,7 @@
 
     function setByKeyPath(obj, keyPath, value) {
         if (!obj || keyPath === undefined) return;
+        if ('isFrozen' in Object && Object.isFrozen(obj)) return;
         if (typeof keyPath !== 'string' && 'length' in keyPath) {
             assert(typeof value !== 'string' && 'length' in value);
             for (var i = 0, l = keyPath.length; i < l; ++i) {


### PR DESCRIPTION
If an immutable object is passed to `put` or `add`, trying to assign to the keypath will throw an exception. In that case, we should just not attempt to modify the object.