### PR TITLE
fixing bug when sync starts when it shoul not and deadlocks the database

### DIFF
--- a/addons/Dexie.Observable/Dexie.Observable.js
+++ b/addons/Dexie.Observable/Dexie.Observable.js
@@ -435,7 +435,9 @@
                                 pollHandle = setTimeout(poll, LOCAL_POLL);
                             });
                         });
-                    }).then(cleanup);
+                    }).then(function () {
+                        cleanup();
+                    });
                     //cleanup();
                     //});
                 });


### PR DESCRIPTION
Hi David, this pull request fixes very strange behaviour of syncable addon working with webservice protocol. Somehow not correct cleanup process does connect existing remote protocols (multiple times?) during db.open() and db.on('ready'), that finally deadlocks db opening. This bug was preventing me from using webservice sync protocol, however ajax protocol from your samples works just fine. I'm happy to nail down it after two days of debugging.
There are two more potentially wrong places, but since I'm not able to reproduce wrong behaviour I'm not touching that.

`readChanges(Observable.latestRevision[db.name]).then(cleanup).then(...)`

`db._syncNodes.update(nodeID, { deleteTimeStamp: 1, lastHeartBeat: 0 }).then(cleanup);`
