### PR TITLE
Enable testing with karma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ samples/typescript/console.js
 samples/typescript/console.js.map
 samples/typescript/utils.js
 samples/typescript/utils.js.map
+
+node_modules/

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,52 @@
+module.exports = function(config) {
+  const configuration = {
+    basePath: '',
+
+    frameworks: [
+      'qunit',
+    ],
+
+    reporters: [
+      'mocha'
+    ],
+
+    client: {
+      captureConsole: false
+    },
+
+    files: [
+      'test/qunit.js',
+      'test/karma-env.js',
+      'src/*.js',
+      'test/dexie-unittest-utils.js',
+      'test/tests-extendability.js',
+      'test/tests-promise.js',
+      'test/tests-table.js',
+      'test/tests-open.js',
+      'test/tests-collection.js',
+      'test/tests-whereclause.js',
+      'test/tests-exception-handling.js',
+      'test/tests-upgrading.js',
+      'test/tests-transaction.js',
+      'test/tests-performance.js',
+      { pattern: 'test/worker.js', included: false },
+    ],
+
+    port: 9876,
+    captureTimeout: 10 * 1000,
+    browserNoActivityTimeout: 10 * 60 * 1000,
+    colors: true,
+
+    browsers: [
+      'Chrome'
+    ],
+
+    plugins: [
+      'karma-qunit',
+      'karma-mocha-reporter',
+      'karma-chrome-launcher'
+    ]
+  };
+
+  config.set(configuration);
+};

--- a/package.json
+++ b/package.json
@@ -18,5 +18,22 @@
   "bugs": {
     "url": "https://github.com/dfahlander/Dexie.js/issues"
   },
-  "homepage": "http://www.dexie.org"
+  "homepage": "http://www.dexie.org",
+
+  "scripts": {
+    "test": "node_modules/.bin/karma start karma.conf.js --single-run --browsers Chrome",
+    "test:debug": "node_modules/.bin/karma start karma.conf.js --browsers Chrome"
+  },
+
+  "engines": {
+    "node": ">=4.2 <5.0"
+  },
+
+  "devDependencies": {
+    "qunit": "^0.7.7",
+    "karma": "^0.13.19",
+    "karma-qunit": "^0.1.9",
+    "karma-mocha-reporter": "^1.1.5",
+    "karma-chrome-launcher": "^0.2.2"
+  }
 }

--- a/test/karma-env.js
+++ b/test/karma-env.js
@@ -1,0 +1,3 @@
+QUnit.config.autostart = false;
+window.workerImports = ['../src/Dexie.js'];
+window.workerSource = 'base/test/worker.js';

--- a/test/tests-open.js
+++ b/test/tests-open.js
@@ -244,6 +244,12 @@ asyncTest("Issue #76 Dexie inside Web Worker", function () {
             break;
         }
     }
+
+    worker.onerror = function(e) {
+        worker.terminate();
+        ok(false, "Worker errored: " + e.message);
+        start();
+    };
 });
 
 asyncTest("Issue#100 - not all indexes are created", function () {
@@ -285,7 +291,7 @@ asyncTest("Issue#100 - not all indexes are created", function () {
         // it should not exist when failed to open.
         db.close();
         db = new Dexie("TestDB");
-        return db.open(); 
+        return db.open();
     }).then(function() {
         ok(false, "Should not succeed to open the database. It should not have been created.");
         equal(db.tables.length, 0, "At least expect no tables to have been created on the database");


### PR DESCRIPTION
This adds ability to test Dexie.js from command line and opens a possibility of spinning up a CI.

For now, I only added core tests, addons test are hader to add because some of them are hardcoded into html files and we need to extract and maybe move them to `tests/addons` folder, so that `addons/` folder will only contain sources and dists.

I've chosen `mocha` reporter due to its readability, but we can discuss that.

Note that:
```javascript
"engines": {
   "node": ">=4.2 <5.0"
 },
```
is relevant only for potential CI env, not real platform support.