### PR TITLE
Bugfixes + new options to Dexie constructor

### DIFF
--- a/src/Promise.js
+++ b/src/Promise.js
@@ -133,7 +133,7 @@ function _rootExec(fn) {
     isRootExecution = false;
     asap = enqueueImmediate;
     try {
-        fn();
+        return fn();
     } finally {
         if (isRootExec) {
             do {

--- a/src/errors.js
+++ b/src/errors.js
@@ -102,14 +102,15 @@ export var exceptions = errorList.reduce((obj,name)=>{
     // and we cannot change Function.name programatically without
     // dynamically create a Function object, which would be considered
     // 'eval-evil'.
+    let fullName = name + "Error";
     function DexieError (msgOrInner, inner){
-        this.name = name + "Error";
+        this.name = fullName;
         if (typeof msgOrInner === 'string') {
             this.message = msgOrInner;
-            this.inner = null;
+            this.inner = inner || null;
         } else if (typeof msgOrInner === 'object') {
-            this.message = msgOrInner.message;
-            this.inner = inner;
+            this.message = `${msgOrInner.name} ${msgOrInner.message}`;
+            this.inner = msgOrInner;
         } else {
             this.message = defaultTexts[name];
             this.inner = null;

--- a/test/tests-open.js
+++ b/test/tests-open.js
@@ -1,5 +1,6 @@
 ﻿import Dexie from 'dexie';
 import {module, stop, start, asyncTest, equal, ok} from 'QUnit';
+import {spawnedTest} from './dexie-unittest-utils';
 
 const async = Dexie.async;
 
@@ -15,6 +16,26 @@ module("open", {
     teardown: function () {
         stop(); Dexie.delete("TestDB").then(start);
     }
+});
+
+spawnedTest("Using db on node should be rejected with MissingAPIError", function*(){
+    let db = new Dexie('TestDB', {
+        indexedDB: undefined,
+        IDBKeyRange: undefined
+    });
+    db.version(1).stores({foo: 'bar'});
+    try {
+        yield db.foo.toArray();
+        ok(false, "Should not get any result because API is missing.");
+    } catch (e) {
+        ok(e instanceof Dexie.MissingAPIError, "Should get MissingAPIError. Got: " + e.name);
+    }
+    try {
+        yield db.open();
+    } catch (e) {
+        ok(e instanceof Dexie.MissingAPIError, "Should get MissingAPIError. Got: " + e.name);
+    }
+
 });
 
 asyncTest("open, add and query data without transaction", 6, function () {


### PR DESCRIPTION
* Bugfix: DexieError.inner not present when it should
* Bugfix: Promises never return on node (when MissingAPIError was thrown)
* Feature: `new Dexie(name, {indexedDB: indexedDBImpl, IDBKeyRange: IDBKeyRangeImpl});` - possible to provide a backend API that Dexie will use instead of window.indexedDB and window.IDBKeyRange provided by the browser or IndexedDBShim.
