### PR TITLE
By default, log to console.error if any Promise was uncaught.

### DIFF
--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -982,23 +982,10 @@ export default function Dexie(dbName, options) {
                 return this.toCollection().and(filterFunction);
             },
             each: function (fn) {
-                var self = this;
-                fake && fn(self.schema.instanceTemplate);
-                return this._idbstore(READONLY, function (resolve, reject, idbstore) {
-                    var req = idbstore.openCursor();
-                    req.onerror = eventRejectHandler(reject, ["calling", "Table.each()", "on", self.name]);
-                    iterate(req, null, fn, resolve, reject, self.hook.reading.fire);
-                });
+                return this.toCollection().each(fn);
             },
             toArray: function (cb) {
-                var self = this;
-                return this._idbstore(READONLY, function (resolve, reject, idbstore) {
-                    fake && resolve([self.schema.instanceTemplate]);
-                    var a = [];
-                    var req = idbstore.openCursor();
-                    req.onerror = eventRejectHandler(reject, ["calling", "Table.toArray()", "on", self.name]);
-                    iterate(req, null, function (item) { a.push(item); }, function () { resolve(a); }, reject, self.hook.reading.fire);
-                }).then(cb);
+                return this.toCollection().toArray(cb);
             },
             orderBy: function (index) {
                 return new this._collClass(new WhereClause(this, index));

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -149,7 +149,7 @@ function _rootExec(fn) {
 
 function setCatched(promise) {
     promise._catched = true;
-    if (promise._parent) setCatched(promise._parent);
+    if (promise._parent && !promise._parent._catched) setCatched(promise._parent);
 }
 
 function resolve(promise, newValue) {

--- a/test/tests-collection.js
+++ b/test/tests-collection.js
@@ -293,7 +293,7 @@ asyncTest("modify-causing-error", 2, function () {
 asyncTest("delete", 2, function () {
     db.users.orderBy("id").delete().then(function (count) {
         equal(count, 2, "All two records deleted");
-        db.users.count(function (count) {
+        return db.users.count(function (count) {
             equal(count, 0, "No users in collection anymore");
         });
     }).catch(function (e) {

--- a/test/tests-exception-handling.js
+++ b/test/tests-exception-handling.js
@@ -247,9 +247,13 @@ asyncTest("catch-all with db.on('error')", 3, function () {
     ourDB.on("error", function (e) {
         ok(errorCount < 3, "Uncatched error successfully bubbled to ourDB.on('error'): " + e);
         if (++errorCount == 3) {
+            Dexie.Promise.on('error').unsubscribe(swallowPromiseOnError);
             ourDB.delete().then(start);
         }
     });
+    function swallowPromiseOnError(e){
+    }
+    Dexie.Promise.on('error', swallowPromiseOnError); // Just to get rid of default error logs for not catching.
 
     ourDB.open();
 

--- a/test/tests-open.js
+++ b/test/tests-open.js
@@ -35,7 +35,6 @@ spawnedTest("Using db on node should be rejected with MissingAPIError", function
     } catch (e) {
         ok(e instanceof Dexie.MissingAPIError, "Should get MissingAPIError. Got: " + e.name);
     }
-
 });
 
 asyncTest("open, add and query data without transaction", 6, function () {

--- a/test/tests-promise.js
+++ b/test/tests-promise.js
@@ -3,28 +3,135 @@ import {module, stop, start, asyncTest, equal, ok} from 'QUnit';
 
 module("promise");
 
-    function createDirectlyResolvedPromise() {
-        return new Dexie.Promise(function(resolve) {
-            resolve();
-        });
+function createDirectlyResolvedPromise() {
+    return new Dexie.Promise(function(resolve) {
+        resolve();
+    });
+}
+
+asyncTest("Promise.on.error should propagate once", 1, function(){
+    var Promise = Dexie.Promise;
+    function logErr (e) {
+        ok(true, e);
     }
+    Promise.on('error', logErr);
+    var p = new Promise((resolve, reject)=>{
+        reject("apa");
+    }).finally(()=>{
 
-    asyncTest("Issue#27(A) - Then handlers are called synchronously for already resolved promises", function () {
-        // Test with plain Dexie.Promise()
-        var expectedLog = ['1', '3', '2', 'a', 'c', 'b'];
-        var log = [];
+    }).finally(()=>{
 
-        var promise = createDirectlyResolvedPromise();
-        log.push('1');
+    });
+    var p2 = p.finally(()=>{});
+    var p3 = p.then(()=>{});
+    var p4 = p.then(()=>{
+
+    }).then(()=>{
+
+    });
+    Promise.all([p, p2, p3, p4]).finally(()=>{
+        setTimeout(()=>{
+            Promise.on('error').unsubscribe(logErr);
+            start();
+        }, 1);
+    });
+});
+
+asyncTest("Promise.on.error should not propagate if catched after finally", 1, function(){
+    var Promise = Dexie.Promise;
+    function logErr (e) {
+        ok(false, "Should already be catched:" + e);
+    }
+    Promise.on('error', logErr);
+    var p = new Promise((resolve, reject)=>{
+        reject("apa");
+    }).finally(()=>{
+
+    }).finally(()=>{
+
+    }).catch(e => {
+        ok(true, "Catching it here: " + e);
+    });
+
+    var p2 = p.finally(()=>{});
+    var p3 = p.then(()=>{});
+    var p4 = p.then(()=>{
+
+    }).then(()=>{
+
+    });
+
+    Promise.all([p, p2, p3, p4]).finally(()=>{
+        setTimeout(()=>{
+            Promise.on('error').unsubscribe(logErr);
+            start();
+        }, 1);
+    });
+});
+
+
+asyncTest("Issue#27(A) - Then handlers are called synchronously for already resolved promises", function () {
+    // Test with plain Dexie.Promise()
+    var expectedLog = ['1', '3', '2', 'a', 'c', 'b'];
+    var log = [];
+
+    var promise = createDirectlyResolvedPromise();
+    log.push('1');
+    promise.then(function() {
+        log.push('2');
+        log.push('a');
         promise.then(function() {
+            log.push('b');
+            check();
+        });
+        log.push('c');
+        check();
+    });
+    log.push('3');
+    check();
+
+    function check() {
+        if (log.length == expectedLog.length) {
+            for (var i = 0; i < log.length; ++i) {
+                equal(log[i], expectedLog[i], "Position " + i + " is " + log[i] + " and was expected to be " + expectedLog[i]);
+            }
+            start();
+        }
+    }
+});
+
+asyncTest("Issue#27(B) - Then handlers are called synchronously for already resolved promises", function () {
+    // Test with a Promise returned from the Dexie library
+    var expectedLog = ['1', '3', '2', 'a', 'c', 'b'];
+    var log = [];
+
+    var db = new Dexie("Promise-test");
+    db.version(1).stores({ friends: '++id' });
+    db.on('populate', function () {
+        db.friends.add({ name: "one" });
+        db.friends.add({ name: "two" });
+        db.friends.add({ name: "three" });
+    });
+    db.delete().then(function () {
+        return db.open();
+    }).then(function () {
+        var promise = db.friends.toCollection().each(function() {});
+        log.push('1');
+        promise.then(function () {
             log.push('2');
             log.push('a');
             promise.then(function() {
                 log.push('b');
                 check();
+            }).catch(function(e) {
+                ok(false, "error: " + e);
+                start();
             });
             log.push('c');
             check();
+        }).catch(function(e) {
+            ok(false, "error: " + e);
+            start();
         });
         log.push('3');
         check();
@@ -34,70 +141,24 @@ module("promise");
                 for (var i = 0; i < log.length; ++i) {
                     equal(log[i], expectedLog[i], "Position " + i + " is " + log[i] + " and was expected to be " + expectedLog[i]);
                 }
-                start();
+                db.delete().then(start);
             }
         }
     });
+});
 
-    asyncTest("Issue#27(B) - Then handlers are called synchronously for already resolved promises", function () {
-        // Test with a Promise returned from the Dexie library
-        var expectedLog = ['1', '3', '2', 'a', 'c', 'b'];
-        var log = [];
+asyncTest("Issue #97 A transaction may be lost after calling Dexie.Promise.resolve().then(...)", function() {
+    Dexie.Promise.newPSD(function () {
 
-        var db = new Dexie("Promise-test");
-        db.version(1).stores({ friends: '++id' });
-        db.on('populate', function () {
-            db.friends.add({ name: "one" });
-            db.friends.add({ name: "two" });
-            db.friends.add({ name: "three" });
-        });
-        db.delete().then(function () {
-            return db.open();
-        }).then(function () {
-            var promise = db.friends.toCollection().each(function() {});
-            log.push('1');
-            promise.then(function () {
-                log.push('2');
-                log.push('a');
-                promise.then(function() {
-                    log.push('b');
-                    check();
-                }).catch(function(e) {
-                    ok(false, "error: " + e);
-                    start();
-                });
-                log.push('c');
-                check();
-            }).catch(function(e) {
-                ok(false, "error: " + e);
-                start();
-            });
-            log.push('3');
-            check();
+        Dexie.Promise.PSD.hello = "promise land";
 
-            function check() {
-                if (log.length == expectedLog.length) {
-                    for (var i = 0; i < log.length; ++i) {
-                        equal(log[i], expectedLog[i], "Position " + i + " is " + log[i] + " and was expected to be " + expectedLog[i]);
-                    }
-                    db.delete().then(start);
-                }
-            }
-        });
+        Dexie.Promise.resolve().then(function () {
+            ok(!!Dexie.Promise.PSD, "We should have a Dexie.Promise.PSD");
+            equal(Dexie.Promise.PSD.hello, "promise land");
+        }).catch(function(e) {
+            ok(false, "Error: " + e);
+        }).finally(start);
+
     });
-
-    asyncTest("Issue #97 A transaction may be lost after calling Dexie.Promise.resolve().then(...)", function() {
-        Dexie.Promise.newPSD(function () {
-
-            Dexie.Promise.PSD.hello = "promise land";
-
-            Dexie.Promise.resolve().then(function () {
-                ok(!!Dexie.Promise.PSD, "We should have a Dexie.Promise.PSD");
-                equal(Dexie.Promise.PSD.hello, "promise land");
-            }).catch(function(e) {
-                ok(false, "Error: " + e);
-            }).finally(start);
-
-        });
-    });
+});
 

--- a/test/tests-transaction.js
+++ b/test/tests-transaction.js
@@ -229,10 +229,12 @@ asyncTest("Three-level sub transactions", function () {
 
 
 asyncTest("Table not in main transactions", function () {
-    db.transaction('rw', db.users, function () {
-        db.users.add({ username: "bertil" });
-        db.transaction('rw', db.users, db.pets, function () {
-            db.pets.add({ kind: "cat" });
+    Dexie.Promise.resolve().then(()=>{
+        return db.transaction('rw', db.users, function () {
+            db.users.add({username: "bertil"});
+            db.transaction('rw', db.users, db.pets, function () {
+                db.pets.add({kind: "cat"});
+            });
         });
     }).then(function () {
         ok(false, "Shouldnt work");


### PR DESCRIPTION
Before, it was nescessary to always explicitely add a line like this somewhere in your bootstrapping code, or you could have issues debugging your code:

```js
Dexie.Promise.on('error', e => console.error(e))
```

But with this change, you don't need to do that anymore unless you'd like to show those errors somewhere else than in the console. Dexie.Promise will by default log any uncaught promise rejection. An exception from this rule is when you do stuff in a transaction scope. You never have to catch those operations but can instead catch the Promise that results from the transaction.

When writing this change, I noticed that Promise.on('error') was actually logging too much. Even though I was catching errors, the event subscriber would sometimes be triggered anyway. So this issue had to be dealt with, resulting in some changes in the Promise class and also in Dexie's transaction method.

Another change from before is that there can only be one subscriber to Promise.on('error'). So if you subscribe to it, the default subscriber wont log anymore, but if you unsubscribe, the default handler will start logging again. If another subscriber was present, also that subscriber will not be triggered anymore until you unsubscribe. This is reasonable because if you subscribe to that error event, the error should not be considered "uncaught" anymore since you now have a chance to handle it.

