### PR TITLE
Syncing stops after status: ERROR_WILL_RETRY

### DIFF
--- a/addons/Dexie.Syncable/src/Dexie.Syncable.js
+++ b/addons/Dexie.Syncable/src/Dexie.Syncable.js
@@ -934,6 +934,9 @@ export default function Syncable (db) {
                 }).then(function(res) {
                     delete context.ongoingOperation;
                     return res;
+                }, function(rej){
+                	delete context.ongoingOperation;
+                    return rej;
                 });
             } else {
                 context.ongoingOperation = context.ongoingOperation.then(function() {


### PR DESCRIPTION
Ensure that syncing is not prevented from retying when an error has occurred.
https://github.com/dfahlander/Dexie.js/issues/39

context.ongoingOperation was never cleared if the promise was rejected, but if the promise was rejected then there was no ongoingOperation so we are allowed to try re-syncing again. An alternative approach to this would be to return the promise to the caller and allow them to catch the rejection and handle the re-sync attempt themselves.
