### PR TITLE
Promise totally rewritten + Cleaner Dexie code

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ samples/
 addons/
 *.njsproj
 .*
+*.log

--- a/addons/Dexie.Observable/package.json
+++ b/addons/Dexie.Observable/package.json
@@ -6,7 +6,9 @@
   "jsnext:main": "src/Dexie.Observable.js",
   "jspm": {
     "format": "cjs",
-    "ignore": ["src/"]
+    "ignore": [
+      "src/"
+    ]
   },
   "repository": {
     "type": "git",
@@ -33,5 +35,8 @@
   },
   "peerDependencies": {
     "dexie": "^1.3.3"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.7.7"
   }
 }

--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -760,7 +760,7 @@ function promisableChain(f1, f2) {
 // 
 
 Observable.latestRevision = {}; // Latest revision PER DATABASE. Example: Observable.latestRevision.FriendsDB = 37;
-Observable.on = Dexie.events(null, "latestRevisionIncremented", "suicideNurseCall", "intercomm", "beforeunload"); // fire(dbname, value);
+Observable.on = Dexie.Events(null, "latestRevisionIncremented", "suicideNurseCall", "intercomm", "beforeunload"); // fire(dbname, value);
 Observable.createUUID = function() {
     // Decent solution from http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript
     var d = Date.now();

--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -456,7 +456,12 @@ export default function Observable(db) {
             if (handledRevision >= latestRevision) return; // Make sure to only run once per revision. (Workaround for IE triggering storage event on same window)
             handledRevision = latestRevision;
             Dexie.vip(function() {
-                readChanges(latestRevision);
+                readChanges(latestRevision).catch('DatabaseClosedError', e=>{
+                    // Handle database closed error gracefully while reading changes.
+                    // Don't bubble to db.on.error or Promise.on.error.
+                    // Even though we intercept the close() method, it might be called when in the middle of
+                    // reading changes and then that flow will cancel with DatabaseClosedError.
+                });
             });
         }
     }
@@ -531,7 +536,14 @@ export default function Observable(db) {
         pollHandle = null;
         var currentInstance = mySyncNode.id;
         Dexie.vip(function() { // VIP ourselves. Otherwise we might not be able to consume intercomm messages from master node before database has finished opening. This would make DB stall forever. Cannot rely on storage-event since it may not always work in some browsers of different processes.
-            readChanges(Observable.latestRevision[db.name]).then(cleanup).then(consumeIntercommMessages).finally(function() {
+            readChanges(Observable.latestRevision[db.name]).then(cleanup).then(consumeIntercommMessages)
+            .catch('DatabaseClosedError', e=>{
+                // Handle database closed error gracefully while reading changes.
+                // Don't bubble to db.on.error or Promise.on.error.
+                // Even though we intercept the close() method, it might be called when in the middle of
+                // reading changes and then that flow will cancel with DatabaseClosedError.
+            })
+            .finally(function() {
                 // Poll again in given interval:
                 if (mySyncNode && mySyncNode.id === currentInstance) {
                     pollHandle = setTimeout(poll, LOCAL_POLL);
@@ -540,6 +552,7 @@ export default function Observable(db) {
         });
     }
 
+    
     function cleanup() {
         var ourSyncNode = mySyncNode;
         if (!ourSyncNode) return Promise.reject("Database closed");

--- a/addons/Dexie.Syncable/package.json
+++ b/addons/Dexie.Syncable/package.json
@@ -6,7 +6,9 @@
   "jsnext:main": "src/Dexie.Syncable.js",
   "jspm": {
     "format": "cjs",
-    "ignore": ["src/"]
+    "ignore": [
+      "src/"
+    ]
   },
   "repository": {
     "type": "git",
@@ -36,5 +38,8 @@
   "peerDependencies": {
     "dexie": "^1.3.3",
     "dexie-observable": "^0.1.8"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.7.7"
   }
 }

--- a/addons/Dexie.Syncable/src/Dexie.Syncable.js
+++ b/addons/Dexie.Syncable/src/Dexie.Syncable.js
@@ -115,7 +115,7 @@ export default function Syncable (db) {
         });
     };
 
-    db.syncable.on = Dexie.events(db, { statusChanged: "asap" });
+    db.syncable.on = Dexie.Events(db, { statusChanged: "asap" });
 
     db.syncable.disconnect = function(url) {
         if (db._localSyncNode && db._localSyncNode.isMaster) {
@@ -228,7 +228,7 @@ export default function Syncable (db) {
             url: url,
             status: Statuses.OFFLINE,
             connectPromise: connectPromise,
-            on: Dexie.events(null, "disconnect"),
+            on: Dexie.Events(null, "disconnect"),
             disconnect: function(newStatus, error) {
                 if (!disconnected) {
                     activePeer.on.disconnect.fire(newStatus, error);

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -23,6 +23,7 @@
     "window": false,
     "global": false,
     "navigator": false,
+    "location": false,
     "chrome": false
   }
 }

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -17,6 +17,7 @@
     "IDBKeyRange": false,
     "setTimeout": false,
     "clearTimeout": false,
+    "Symbol": false,
     "setImmediate": false,
     "console": false,
     "self": false,

--- a/src/Dexie.d.ts
+++ b/src/Dexie.d.ts
@@ -50,8 +50,6 @@ declare class Dexie {
     static asap(fn: Function) : void;
     
     static maxKey: Array<string>;
-
-    static dump(error:any):string;
     
     static dependencies: {
         indexedDB: IDBFactory,
@@ -406,7 +404,6 @@ declare module Dexie {
 
         constructor (name?:string, message?:string);
         toString(): string;
-        dump(): string;
     }
     
     class ModifyError extends DexieError{

--- a/src/Dexie.d.ts
+++ b/src/Dexie.d.ts
@@ -311,6 +311,7 @@ declare module Dexie {
         each(callback: (obj: T, cursor: IDBCursor) => any): Promise<void>;
         eachKey(callback: (key: Key, cursor: IDBCursor) => any): Promise<void>;
         eachUniqueKey(callback: (key: Key, cursor: IDBCursor) => any): Promise<void>;
+        filter(filter: (x: T) => boolean): Collection<T, Key>;
         first(): Promise<T>;
         first<U>(onFulfilled: (value: T) => Thenable<U>): Promise<U>;
         first<U>(onFulfilled: (value: T) => U): Promise<U>;

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -480,7 +480,6 @@ export default function Dexie(dbName, options) {
     this.open = function () {
         if (isBeingOpened || idbdb)
             return dbReadyPromise.then(()=> dbOpenError ? rejection(dbOpenError, dbUncaught) : db);
-        //if (Debug.debug) console.log("Calling open(): " + Debug.prettyStack(Debug.getErrorWithStack()));
         Debug.debug && (openCanceller._stackHolder = Debug.getErrorWithStack()); // Let stacks point to when open() was called rather than where new Dexie() was called.
         isBeingOpened = true;
         dbOpenError = null;

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -2323,7 +2323,7 @@ export default function Dexie(dbName, options) {
                 return this.reverse().first(cb);
             },
 
-            and: function (filterFunction) {
+            filter: function (filterFunction) {
                 /// <param name="jsFunctionFilter" type="Function">function(val){return true/false}</param>
                 fake && filterFunction(getInstanceTemplate(this._ctx));
                 addFilter(this._ctx, function (cursor) {
@@ -2331,6 +2331,10 @@ export default function Dexie(dbName, options) {
                 });
                 addMatchFilter(this._ctx, filterFunction); // match filters not used in Dexie.js but can be used by 3rd part libraries to test a collection for a match without querying DB. Used by Dexie.Observable.
                 return this;
+            },
+            
+            and: function (filterFunction) {
+                return this.filter(filterFunction);
             },
 
             or: function (indexName) {

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -1592,9 +1592,9 @@ export default function Dexie(dbName, options) {
                 if (!self._locked()) {
                     p = self.active ? new Promise(function (resolve, reject) {
                         if (!self.idbtrans && mode) {
-                            if (!idbdb) throw (!dbOpenError) || ["DatabaseClosedError","MissingAPIError"].indexOf(dbOpenError.name) >= 0 ?
+                            if (!idbdb) {throw (dbOpenError && ["DatabaseClosedError","MissingAPIError"].indexOf(dbOpenError.name) >= 0 ?
                                 dbOpenError : // Errors where it is no difference whether it was caused by the user operation or an earlier call to db.open()
-                                new exceptions.OpenFailed(dbOpenError); // Make it clear that the user operation was not what caused the error - the error had occurred earlier on db.open()!
+                                new exceptions.OpenFailed(dbOpenError));} // Make it clear that the user operation was not what caused the error - the error had occurred earlier on db.open()!
 
                             var idbtrans = self.idbtrans = idbdb.transaction(safariMultiStoreFix(self.storeNames), self.mode);
                             idbtrans.onerror = function (e) {

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -1457,6 +1457,8 @@ export default function Dexie(dbName, options) {
                 // Read lock always
                 if (!self._locked()) {
                     p = self.active ? new Promise(function (resolve, reject) {
+                        if (mode === READWRITE && self.mode !== READWRITE)
+                            throw new exceptions.ReadOnly("Transaction is readonly");
                         if (!self.idbtrans && mode) self.create();
                         if (bWriteLock) self._lock(); // Write lock if write operation is requested
                         fn(resolve, reject, self);

--- a/src/Events.js
+++ b/src/Events.js
@@ -6,8 +6,10 @@ export default function Events(ctx) {
     var evs = {};
     var rv = function (eventName, subscriber) {
         if (subscriber) {
-            // Subscribe
-            evs[eventName].subscribe(subscriber);
+            // Subscribe. If additional arguments than just the subscriber was provided, forward them as well.
+            var i = arguments.length, args = new Array(i - 1);
+            while (--i) args[i - 1] = arguments[i];
+            evs[eventName].subscribe.apply(null, args);
             return ctx;
         } else if (typeof (eventName) === 'string') {
             // Return interface allowing to fire or unsubscribe from event

--- a/src/Events.js
+++ b/src/Events.js
@@ -1,5 +1,5 @@
 import {slice, keys, isArray, asap, _global} from './utils';
-import {nop, stoppableEventChain} from './chaining-functions';
+import {nop, reverseStoppableEventChain} from './chaining-functions';
 import {exceptions} from './errors';
 
 export default function Events(ctx) {
@@ -22,7 +22,7 @@ export default function Events(ctx) {
     function add(eventName, chainFunction, defaultFunction) {
         if (isArray(eventName)) return addEventGroup(eventName);
         if (typeof eventName === 'object') return addConfiguredEvents(eventName);
-        if (!chainFunction) chainFunction = stoppableEventChain;
+        if (!chainFunction) chainFunction = reverseStoppableEventChain;
         if (!defaultFunction) defaultFunction = nop;
 
         var context = {

--- a/src/Events.js
+++ b/src/Events.js
@@ -1,16 +1,13 @@
-import {slice, keys, isArray, asap, _global} from './utils';
-import {nop, reverseStoppableEventChain} from './chaining-functions';
+import {keys, isArray, asap} from './utils';
+import {nop, mirror, reverseStoppableEventChain} from './chaining-functions';
 import {exceptions} from './errors';
 
 export default function Events(ctx) {
-    var args = arguments;
     var evs = {};
     var rv = function (eventName, subscriber) {
         if (subscriber) {
             // Subscribe
-            var args = slice(arguments, 1);
-            var ev = evs[eventName];
-            ev.subscribe.apply(ev, args);
+            evs[eventName].subscribe(subscriber);
             return ctx;
         } else if (typeof (eventName) === 'string') {
             // Return interface allowing to fire or unsubscribe from event
@@ -18,9 +15,14 @@ export default function Events(ctx) {
         }
     };
     rv.addEventType = add;
+    
+    for (var i = 1, l = arguments.length; i < l; ++i) {
+        add(arguments[i]);
+    }
+    
+    return rv;
 
     function add(eventName, chainFunction, defaultFunction) {
-        if (isArray(eventName)) return addEventGroup(eventName);
         if (typeof eventName === 'object') return addConfiguredEvents(eventName);
         if (!chainFunction) chainFunction = reverseStoppableEventChain;
         if (!defaultFunction) defaultFunction = nop;
@@ -29,8 +31,10 @@ export default function Events(ctx) {
             subscribers: [],
             fire: defaultFunction,
             subscribe: function (cb) {
-                context.subscribers.push(cb);
-                context.fire = chainFunction(context.fire, cb);
+                if (context.subscribers.indexOf(cb) === -1) {
+                    context.subscribers.push(cb);
+                    context.fire = chainFunction(context.fire, cb);
+                }
             },
             unsubscribe: function (cb) {
                 context.subscribers = context.subscribers.filter(function (fn) { return fn !== cb; });
@@ -50,43 +54,18 @@ export default function Events(ctx) {
             } else if (args === 'asap') {
                 // Rather than approaching event subscription using a functional approach, we here do it in a for-loop where subscriber is executed in its own stack
                 // enabling that any exception that occur wont disturb the initiator and also not nescessary be catched and forgotten.
-                var context = add(eventName, null, function fire() {
-                    var args = arguments;
+                var context = add(eventName, mirror, function fire() {
+                    // Optimazation-safe cloning of arguments into args.
+                    var i = arguments.length, args = new Array(i);
+                    while (i--) args[i] = arguments[i];
+                    // All each subscriber:
                     context.subscribers.forEach(function (fn) {
                         asap(function fireEvent() {
-                            fn.apply(_global, args);
+                            fn.apply(null, args);
                         });
                     });
                 });
-                context.subscribe = function (fn) {
-                    // Change how subscribe works to not replace the fire function but to just add the subscriber to subscribers
-                    if (context.subscribers.indexOf(fn) === -1)
-                        context.subscribers.push(fn);
-                };
-                context.unsubscribe = function (fn) {
-                    // Change how unsubscribe works for the same reason as above.
-                    var idxOfFn = context.subscribers.indexOf(fn);
-                    if (idxOfFn !== -1) context.subscribers.splice(idxOfFn, 1);
-                };
             } else throw new exceptions.InvalidArgument("Invalid event config");
         });
     }
-
-    function addEventGroup(eventGroup) {
-        // promise-based event group (i.e. we promise to call one and only one of the events in the pair, and to only call it once.
-        var done = false;
-        eventGroup.forEach(function (name) {
-            add(name).subscribe(checkDone);
-        });
-        function checkDone() {
-            if (done) return false;
-            done = true;
-        }
-    }
-
-    for (var i = 1, l = args.length; i < l; ++i) {
-        add(args[i]);
-    }
-
-    return rv;
 }

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -1,5 +1,5 @@
-import {_global, slice, isArray, doFakeAutoComplete, messageAndStack} from './utils';
-import { nop } from './chaining-functions';
+import {_global, slice, isArray, doFakeAutoComplete, messageAndStack, miniTryCatch, extendProto} from './utils';
+import {reverseStoppableEventChain} from './chaining-functions';
 import Events from './Events';
 
 //
@@ -21,14 +21,24 @@ import Events from './Events';
 // errors to the transaction. We must not rely on IndexedDB implementation to do this, because it only does so when the source of the rejection
 // is an error event on a request, not in case an ordinary exception is thrown.
 
-var _asap = _global.setImmediate || function(fn) {
-    var args = slice(arguments, 1);
-
-        // If not FF13 and earlier failed, we could use this call here instead: setTimeout.call(this, [fn, 0].concat(arguments));
-    setTimeout(function() {
-        fn.apply(_global, args);
-    }, 0);
-};
+var _asap = (typeof setImmediate === 'undefined' ? function(fn, args) {
+    // BUGBUG: FF13 and earlier fails passing correct arguments to setTimout callback. TODO: Should safe up here and use closure and upgrade after successful test. 
+    setTimeout(function(fn, args){
+        isRootExecution = false;
+        asap = enqueueImmediate;
+        fn.apply(null, args);
+        endMicroTickScope();
+    }, 0, fn, args);
+} : function (fn, args) {
+    setImmediate(function(fn, args){
+        //try {
+        isRootExecution = false;
+        asap = enqueueImmediate;
+        fn.apply(null, args);
+        endMicroTickScope();
+        //} catch (e) {alert (e);}
+    }, fn, args);
+});
 
 doFakeAutoComplete(function () {
     // Simplify the job for VS Intellisense. This piece of code is one of the keys to the new marvellous intellisense support in Dexie.
@@ -38,21 +48,13 @@ doFakeAutoComplete(function () {
 });
 
 var asap = _asap,
-    isRootExecution = true;
+    isRootExecution = true,
+    tickErrors = [];
 
 var operationsQueue = [];
 var tickFinalizers = [];
-var enqueueImmediate = function (fn) {
-    operationsQueue.push([fn, slice(arguments, 1)]);
-}
-
-function executeOperationsQueue() {
-    var queue = operationsQueue;
-    operationsQueue = [];
-    for (var i = 0, l = queue.length; i < l; ++i) {
-        var item = queue[i];
-        item[0].apply(_global, item[1]);
-    }
+var enqueueImmediate = function (fn, args) {
+    operationsQueue.push([fn, args]);
 }
 
 export default function Promise(fn) {
@@ -60,149 +62,138 @@ export default function Promise(fn) {
     if (typeof fn !== 'function') throw new TypeError('not a function');
     this._state = null; // null (=pending), false (=rejected) or true (=resolved)
     this._value = null; // error or result
-    this._deferreds = [];
+    this._deferreds = [];//new Array(1); // Normally there will only be one deferred. Optimize for this.
     this._catched = false; // for onuncatched
-    //this._id = ++PromiseID;
-    var self = this;
-    var constructing = true;
     this._PSD = Promise.PSD;
 
-    try {
-        doResolve(this, fn, function (data) {
-            if (constructing)
-                asap(resolve, self, data);
-            else
-                resolve(self, data);
-        }, function (reason) {
-            if (constructing) {
-                asap(reject, self, reason);
-                return false;
-            } else {
-                return reject(self, reason);
-            }
-        });
-    } finally {
-        constructing = false;
-    }
+    this._doResolve(fn);
 }
 
-function handle(self, deferred) {
-    if (self._state === null) {
-        self._deferreds.push(deferred);
+
+extendProto(Promise.prototype, {
+    /**
+    * Take a potentially misbehaving resolver function and make sure
+    * onFulfilled and onRejected are only called once.
+    *
+    * Makes no guarantees about asynchrony.
+    */
+    _doResolve: function (fn) {
+        // Promise Resolution Procedure:
+        // https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure
+        var done = false;
+        try {
+            fn(value => {
+                if (done) return;
+                this._state = true;
+                this._value = value;
+                if (value === this) throw new TypeError('A promise cannot be resolved with itself.');
+                if (value && (typeof value === 'object' || typeof value === 'function')) {
+                    if (typeof value.then === 'function') {
+                        this._doResolve((resolve, reject) => {
+                            value.then(resolve, reject);
+                        });
+                        return;
+                    }
+                }
+                done = true;
+                this._finale();
+            }, reason => {
+                if (done) return;
+                done = true;
+                this._state = false;
+                this._value = reason;
+                this._finale();
+            });
+        } catch (ex) {
+            if (done) return;
+            done = true;
+            this._state = false;
+            this._value = ex;
+            this._finale();
+        }
+    },
+
+    _finale: function () {
+        var wasRootExec = beginMicroTickScope();
+        for (var i = 0, len = this._deferreds.length; i < len; i++) {
+            handle(this, this._deferreds[i]);
+        }
+        this._deferreds = [];
+        if (wasRootExec) endMicroTickScope();
+        else if (this._state === false) {
+            addTickError(this);
+        }
+    },
+    
+    then: function (onFulfilled, onRejected) {
+        var p = new Promise((resolve, reject) => {
+            handle(this, new Deferred(onFulfilled, onRejected, resolve, reject));
+        });
+        p._PSD = this._PSD;
+        p.onuncatched = this.onuncatched; // Needed when exception occurs in a then() clause of a successful parent promise. Want onuncatched to be called even in callbacks of callbacks of the original promise.
+        p._parent = this; // Used for recursively calling setCatched() on self and all parents.
+        return p;
+    },
+
+    'catch': function (onRejected) {
+        if (arguments.length === 1) return this.then(null, onRejected);
+        // First argument is the Error type to catch
+        var type = arguments[0], callback = arguments[1];
+        if (typeof type === 'function') return this.then(null, function (e) {
+            // Catching errors by its constructor type (similar to java / c++ / c#)
+            // Sample: promise.catch(TypeError, function (e) { ... });
+            if (e instanceof type) return callback(e); else return Promise.reject(e);
+        });
+        else return this.then(null, function (e) {
+            // Catching errors by the error.name property. Makes sense for indexedDB where error type
+            // is always DOMError but where e.name tells the actual error type.
+            // Sample: promise.catch('ConstraintError', function (e) { ... });
+            if (e && e.name === type) return callback(e); else return Promise.reject(e);
+        });
+    },
+
+    'finally': function (onFinally) {
+        return this.then(function (value) {
+            onFinally();
+            return value;
+        }, function (err) {
+            onFinally();
+            return Promise.reject(err);
+        });
+    },
+
+    onuncatched: null // Optional event triggered if promise is rejected but no one listened.
+});
+
+function handle(promise, deferred) {
+    if (promise._state === null) {
+        promise._deferreds.push(deferred);
         return;
     }
 
-    var cb = self._state ? deferred.onFulfilled : deferred.onRejected;
+    var cb = promise._state ? deferred.onFulfilled : deferred.onRejected;
     if (cb === null) {
         // This Deferred doesnt have a listener for the event being triggered (onFulfilled or onReject) so lets forward the event to any eventual listeners on the Promise instance returned by then() or catch()
-        return (self._state ? deferred.resolve : deferred.reject)(self._value);
+        return (promise._state ? deferred.resolve : deferred.reject)(promise._value);
     }
-    var ret, isRootExec = isRootExecution;
-    isRootExecution = false;
-    asap = enqueueImmediate;
+    asap(call, [promise, cb, deferred]);
+}
+
+function call (promise, cb, deferred) {
+    var outerPSD = Promise.PSD;
     try {
-        var outerPSD = Promise.PSD;
-        Promise.PSD = self._PSD;
-        ret = cb(self._value);
-        if (!self._state && (!ret || typeof ret.then !== 'function' || ret._state !== false)) setCatched(self); // Caller did 'return Promise.reject(err);' - don't regard it as catched!
+        Promise.PSD = promise._PSD;
+        var ret = cb(promise._value);
+        if (!promise._state && (!ret ||
+              typeof ret.then !== 'function' ||
+              ret._state !== false)) // If 'return Promise.reject(err);' - don't regard it as catched!
+            setCatched(promise); 
         deferred.resolve(ret);
     } catch (e) {
         deferred.reject(e);
     } finally {
         Promise.PSD = outerPSD;
-        if (isRootExec) {
-            do {
-                while (operationsQueue.length > 0) executeOperationsQueue();
-                var finalizer = tickFinalizers.pop();
-                if (finalizer) try {finalizer();} catch(e){}
-            } while (tickFinalizers.length > 0 || operationsQueue.length > 0);
-            asap = _asap;
-            isRootExecution = true;
-        }
     }
-}
-
-function _rootExec(fn) {
-    var isRootExec = isRootExecution;
-    isRootExecution = false;
-    asap = enqueueImmediate;
-    try {
-        return fn();
-    } finally {
-        if (isRootExec) {
-            do {
-                while (operationsQueue.length > 0) executeOperationsQueue();
-                var finalizer = tickFinalizers.pop();
-                if (finalizer) try { finalizer(); } catch (e) { }
-            } while (tickFinalizers.length > 0 || operationsQueue.length > 0);
-            asap = _asap;
-            isRootExecution = true;
-        }
-    }
-}
-
-function setCatched(promise) {
-    promise._catched = true;
-    if (promise._parent && !promise._parent._catched) setCatched(promise._parent);
-}
-
-function resolve(promise, newValue) {
-    var outerPSD = Promise.PSD;
-    Promise.PSD = promise._PSD;
-    try { //Promise Resolution Procedure: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure
-        if (newValue === promise) throw new TypeError('A promise cannot be resolved with itself.');
-        if (newValue && (typeof newValue === 'object' || typeof newValue === 'function')) {
-            if (typeof newValue.then === 'function') {
-                if (newValue instanceof Promise && newValue._state !== null) {
-                    promise._state = newValue._state;
-                    promise._value = newValue._value;
-                    finale.call(promise);
-                    return;
-                }
-                doResolve(promise, function (resolve, reject) {
-                    //newValue instanceof Promise ? newValue._then(resolve, reject) : newValue.then(resolve, reject);
-                    newValue.then(resolve, reject);
-                }, function (data) {
-                    resolve(promise, data);
-                }, function (reason) {
-                    reject(promise, reason);
-                });
-                return;
-            }
-        }
-        promise._state = true;
-        promise._value = newValue;
-        finale.call(promise);
-    } catch (e) { reject(e); } finally {
-        Promise.PSD = outerPSD;
-    }
-}
-
-function reject(promise, newValue) {
-    var outerPSD = Promise.PSD;
-    Promise.PSD = promise._PSD;
-    promise._state = false;
-    promise._value = newValue;
-
-    finale.call(promise);
-    if (!promise._catched ) {
-        try {
-            if (promise.onuncatched)
-                promise.onuncatched(promise._value);
-            else
-                Promise.on.error.fire(promise._value);
-        } catch (e) {
-        }
-    }
-    Promise.PSD = outerPSD;
-    return promise._catched;
-}
-
-function finale() {
-    for (var i = 0, len = this._deferreds.length; i < len; i++) {
-        handle(this, this._deferreds[i]);
-    }
-    this._deferreds = [];
 }
 
 function Deferred(onFulfilled, onRejected, resolve, reject) {
@@ -212,163 +203,150 @@ function Deferred(onFulfilled, onRejected, resolve, reject) {
     this.reject = reject;
 }
 
-/**
-    * Take a potentially misbehaving resolver function and make sure
-    * onFulfilled and onRejected are only called once.
-    *
-    * Makes no guarantees about asynchrony.
-    */
-function doResolve(promise, fn, onFulfilled, onRejected) {
-    var done = false;
-    try {
-        fn(function Promise_resolve(value) {
-            if (done) return;
-            done = true;
-            onFulfilled(value);
-        }, function Promise_reject(reason) {
-            if (done) return promise._catched;
-            done = true;
-            return onRejected(reason);
+extendProto(Promise, {
+    all: function () {
+        var args = slice(arguments.length === 1 && isArray(arguments[0]) ? arguments[0] : arguments);
+
+        return new Promise(function (resolve, reject) {
+            if (args.length === 0) return resolve([]);
+            var remaining = args.length;
+            function res(i, val) {
+                try {
+                    if (val && (typeof val === 'object' || typeof val === 'function')) {
+                        var then = val.then;
+                        if (typeof then === 'function') {
+                            then.call(val, function (val) { res(i, val); }, reject);
+                            return;
+                        }
+                    }
+                    args[i] = val;
+                    if (--remaining === 0) {
+                        resolve(args);
+                    }
+                } catch (ex) {
+                    reject(ex);
+                }
+            }
+            for (var i = 0; i < args.length; i++) {
+                res(i, args[i]);
+            }
         });
-    } catch (ex) {
-        if (done) return;
-        return onRejected(ex);
+    },
+    
+    resolve: value => {
+        if (value && typeof value.then === 'function') return value;
+        var p = new Promise(function () { });
+        p._state = true;
+        p._value = value;
+        return p;
+    },
+    
+    reject: reason => {
+        var p = new Promise(function () { });
+        p._state = false;
+        p._value = reason;
+        return p;
+    },
+    
+    race: values => new Promise((resolve, reject) => {
+        values.map(value => Promise.resolve(value).then(resolve, reject));
+    }),
+    
+    PSD: null,// Promise Specific Data - a TLS Pattern (Thread Local Storage) for Promises.
+    
+    newPSD: fn => {
+        // Create new PSD scope (Promise Specific Data)
+        var outerScope = Promise.PSD;
+        Promise.PSD = outerScope ? Object.create(outerScope) : {};
+        try {
+            return fn();
+        } finally {
+            Promise.PSD = outerScope;
+        }
+    },
+
+    usePSD: (psd, fn) => {
+        var outerScope = Promise.PSD;
+        Promise.PSD = psd;
+        try {
+            return fn();
+        } finally {
+            Promise.PSD = outerScope;
+        }
+    },
+
+    _rootExec: _rootExec,
+    
+    _tickFinalize: callback => {
+        if (isRootExecution) throw new Error("Not in a virtual tick");
+        tickFinalizers.push(callback);
+    },
+    
+    on: Events(null, {"error": [
+        reverseStoppableEventChain,
+        defaultErrorHandler] // Default to defaultErrorHandler
+    }),
+    
+    _isRootExec: {get: ()=> isRootExecution}
+});
+
+function addTickError(promise) {
+    // If this error was already added, replace it with given promise, because
+    // parents are added later and the topmost parent promise is the interesting one.
+    // Else push p to tickErrors.
+    if (!tickErrors.some((p,i) =>
+        p._value === promise._value && (tickErrors[i] = promise) 
+    )) tickErrors.push(promise);
+}
+
+function beginMicroTickScope() {
+    var isRootExec = isRootExecution;
+    isRootExecution = false;
+    asap = enqueueImmediate;
+    return isRootExec;
+}
+
+function endMicroTickScope() {
+    var queue, i, l;
+    do {
+        while (operationsQueue.length > 0) {
+            queue = operationsQueue;
+            operationsQueue = [];
+            l = queue.length;
+            for (i = 0; i < l; ++i) {
+                var item = queue[i];
+                item[0].apply(null, item[1]);
+            }
+        }
+        var finalizer = tickFinalizers.pop();
+        if (finalizer) try { finalizer(); } catch (e) { }
+    } while (tickFinalizers.length > 0 || operationsQueue.length > 0);
+    asap = _asap;
+    isRootExecution = true;
+    if (tickErrors.length) {
+        tickErrors.forEach(p => {
+            if (!p._catched) miniTryCatch(()=>{
+                (!p.onuncatched || p.onuncatched(p._value))
+                && Promise.on.error.fire(p._value, p);
+            });
+        });
+        tickErrors = [];
     }
 }
 
-Promise.all = function () {
-    var args = slice(arguments.length === 1 && isArray(arguments[0]) ? arguments[0] : arguments);
-
-    return new Promise(function (resolve, reject) {
-        if (args.length === 0) return resolve([]);
-        var remaining = args.length;
-        function res(i, val) {
-            try {
-                if (val && (typeof val === 'object' || typeof val === 'function')) {
-                    var then = val.then;
-                    if (typeof then === 'function') {
-                        then.call(val, function (val) { res(i, val); }, reject);
-                        return;
-                    }
-                }
-                args[i] = val;
-                if (--remaining === 0) {
-                    resolve(args);
-                }
-            } catch (ex) {
-                reject(ex);
-            }
-        }
-        for (var i = 0; i < args.length; i++) {
-            res(i, args[i]);
-        }
-    });
-};
-
-/* Prototype Methods */
-Promise.prototype.then = function (onFulfilled, onRejected) {
-    var self = this;
-    var p = new Promise(function (resolve, reject) {
-        if (self._state === null)
-            handle(self, new Deferred(onFulfilled, onRejected, resolve, reject));
-        else
-            asap(handle, self, new Deferred(onFulfilled, onRejected, resolve, reject));
-    });
-    p._PSD = this._PSD;
-    p.onuncatched = this.onuncatched; // Needed when exception occurs in a then() clause of a successful parent promise. Want onuncatched to be called even in callbacks of callbacks of the original promise.
-    p._parent = this; // Used for recursively calling onuncatched event on self and all parents.
-    return p;
-};
-
-Promise.prototype._then = function (onFulfilled, onRejected) {
-    handle(this, new Deferred(onFulfilled, onRejected, nop,nop));
-};
-
-Promise.prototype['catch'] = function (onRejected) {
-    if (arguments.length === 1) return this.then(null, onRejected);
-    // First argument is the Error type to catch
-    var type = arguments[0], callback = arguments[1];
-    if (typeof type === 'function') return this.then(null, function (e) {
-        // Catching errors by its constructor type (similar to java / c++ / c#)
-        // Sample: promise.catch(TypeError, function (e) { ... });
-        if (e instanceof type) return callback(e); else return Promise.reject(e);
-    });
-    else return this.then(null, function (e) {
-        // Catching errors by the error.name property. Makes sense for indexedDB where error type
-        // is always DOMError but where e.name tells the actual error type.
-        // Sample: promise.catch('ConstraintError', function (e) { ... });
-        if (e && e.name === type) return callback(e); else return Promise.reject(e);
-    });
-};
-
-Promise.prototype['finally'] = function (onFinally) {
-    return this.then(function (value) {
-        onFinally();
-        return value;
-    }, function (err) {
-        onFinally();
-        return Promise.reject(err);
-    });
-};
-
-Promise.prototype.onuncatched = null; // Optional event triggered if promise is rejected but no one listened.
-
-Promise.resolve = function (value) {
-    if (value && typeof value.then === 'function') return value;
-    var p = new Promise(function () { });
-    p._state = true;
-    p._value = value;
-    return p;
-};
-
-Promise.reject = function (value) {
-    var p = new Promise(function () { });
-    p._state = false;
-    p._value = value;
-    return p;
-};
-
-Promise.race = function (values) {
-    return new Promise(function (resolve, reject) {
-        values.map(function (value) {
-            value.then(resolve, reject);
-        });
-    });
-};
-
-Promise.PSD = null; // Promise Specific Data - a TLS Pattern (Thread Local Storage) for Promises. TODO: Rename Promise.PSD to Promise.data
-
-Promise.newPSD = function (fn) {
-    // Create new PSD scope (Promise Specific Data)
-    var outerScope = Promise.PSD;
-    Promise.PSD = outerScope ? Object.create(outerScope) : {};
+function _rootExec(fn) {
+    var isRootExec = beginMicroTickScope();
     try {
         return fn();
     } finally {
-        Promise.PSD = outerScope;
+        if (isRootExec) endMicroTickScope();
     }
-};
+}
 
-Promise.usePSD = function (psd, fn) {
-    var outerScope = Promise.PSD;
-    Promise.PSD = psd;
-    try {
-        return fn();
-    } finally {
-        Promise.PSD = outerScope;
-    }
-};
-
-Promise._rootExec = _rootExec;
-Promise._tickFinalize = function(callback) {
-    if (isRootExecution) throw new Error("Not in a virtual tick");
-    tickFinalizers.push(callback);
-};
-
-Promise.on = Events(null, {"error": [
-    (f1,f2)=>f2, // Only use the most recent handler (only allow one handler at a time).
-    defaultErrorHandler] // Default to defaultErrorHandler
-});
+function setCatched(promise) {
+    promise._catched = true;
+    if (promise._parent && !promise._parent._catched) setCatched(promise._parent);
+}
 
 // By default, log uncaught errors to the console
 function defaultErrorHandler(e) {

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -1,4 +1,4 @@
-import {slice, isArray, doFakeAutoComplete, miniTryCatch, setProps, setProp, _global} from './utils';
+import {slice, isArray, doFakeAutoComplete, tryCatch, setProps, setProp, _global} from './utils';
 import {reverseStoppableEventChain, nop, callBoth, mirror} from './chaining-functions';
 import Events from './Events';
 import {debug, prettyStack, NEEDS_THROW_FOR_STACK} from './debug';
@@ -351,7 +351,7 @@ function handleRejection (promise, reason) {
     reason = Promise.rejectionMapper(reason);
     promise._state = false;
     promise._value = reason;
-    debug && reason !== null && !reason._promise && typeof reason === 'object' && miniTryCatch(()=>{
+    debug && reason !== null && !reason._promise && typeof reason === 'object' && tryCatch(()=>{
         var origProp =
             Object.getOwnPropertyDescriptor(reason, "stack") ||
             Object.getOwnPropertyDescriptor(Object.getPrototypeOf(reason), "stack");

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -73,6 +73,7 @@ var asap = function (callback, args, macroScheduler) {
 var isOutsideMicroTick = true, // True when NOT in a virtual microTick.
     needsNewPhysicalTick = true, // True when a push to deferredCallbacks must also schedulePhysicalTick()
     unhandledErrors = [], // Rejected promises that has occured. Used for firing Promise.on.error and promise.onuncatched.
+    rejectingErrors = [], // Tracks if errors are being re-rejected during onRejected callback.
     currentFulfiller = null,
     rejectionMapper = mirror;
     
@@ -370,8 +371,6 @@ function executePromiseTask (promise, fn) {
         handleRejection(promise, ex);
     }
 }
-
-var rejectingErrors = [];
 
 function handleRejection (promise, reason) {
     rejectingErrors.push(reason);

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -175,6 +175,10 @@ props(Promise.prototype, {
         debug && (!this._prev || this._state === null) && linkToPreviousPromise(rv, this);
         return rv;
     },
+    
+    _then: function (onFulfilled, onRejected) {
+        propagateToListener(this, new Listener(null, null, onFulfilled, onRejected));        
+    },
 
     catch: function (onRejected) {
         if (arguments.length === 1) return this.then(null, onRejected);
@@ -355,7 +359,7 @@ function executePromiseTask (promise, fn) {
                 if (typeof value.then === 'function') {
                     executePromiseTask(promise, (resolve, reject) => {
                         value instanceof Promise ?
-                            propagateToListener(value, new Listener(null, null, resolve, reject)) :
+                            value._then(resolve, reject) :
                             value.then(resolve, reject);
                     });
                     if (shouldExecuteTick) endMicroTickScope();

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,0 +1,30 @@
+// By default, debug will be true only if platform is a web platform and its page is served from localhost.
+// When debug = true, error's stacks will contain asyncronic long stacks.
+export var debug = typeof location !== 'undefined' &&
+        // By default, use debug mode if served from localhost.
+        /^(http|https):\/\/(localhost|127\.0\.0\.1)/.test(location.href);
+
+export function setDebug(value, filter) {
+    debug = value;
+    libraryFilter = filter;
+}
+
+export var libraryFilter = ()=>true;
+
+export function prettyStack(e) {
+    var stack = e.stack;
+    if (!stack) return "";
+    //var frames = stack.split('\n');
+    //if (frames.length && frames[0].indexOf(e.name) === 0)
+    //if (stack.indexOf(e.name) === 0) stack = stack.substr(e.name.length);
+    return stack.split('\n')
+        //.filter(frame => !/^Error/.test(frame))
+        .filter(frame => frame.indexOf(''+e.name) != 0) // First line: "Error: message\n"
+        .filter(libraryFilter)
+                //(!libraryFilter || prettyStack.filter(frame)))
+                /*(debug === 'dexie' ||                   // If debug
+                !/(dexie\.js|dexie\.min\.js)/.test(frame))) // Ignore frames from dexie lib - focus on application
+        //.slice(0, 3)*/
+        .map(frame => "\n" + frame)
+        .join('');
+}

--- a/src/debug.js
+++ b/src/debug.js
@@ -11,20 +11,14 @@ export function setDebug(value, filter) {
 
 export var libraryFilter = ()=>true;
 
-export function prettyStack(e) {
-    var stack = e.stack;
+export const NEEDS_THROW_FOR_STACK = !new Error("").stack;
+
+export function prettyStack(exception, numIgnoredLines) {
+    var stack = exception.stack;
     if (!stack) return "";
-    //var frames = stack.split('\n');
-    //if (frames.length && frames[0].indexOf(e.name) === 0)
-    //if (stack.indexOf(e.name) === 0) stack = stack.substr(e.name.length);
     return stack.split('\n')
-        //.filter(frame => !/^Error/.test(frame))
-        .filter(frame => frame.indexOf(''+e.name) != 0) // First line: "Error: message\n"
+        .slice(numIgnoredLines || 0)
         .filter(libraryFilter)
-                //(!libraryFilter || prettyStack.filter(frame)))
-                /*(debug === 'dexie' ||                   // If debug
-                !/(dexie\.js|dexie\.min\.js)/.test(frame))) // Ignore frames from dexie lib - focus on application
-        //.slice(0, 3)*/
         .map(frame => "\n" + frame)
         .join('');
 }

--- a/src/debug.js
+++ b/src/debug.js
@@ -9,7 +9,7 @@ export function setDebug(value, filter) {
     libraryFilter = filter;
 }
 
-export var libraryFilter = ()=>true;
+export var libraryFilter = () => true;
 
 export const NEEDS_THROW_FOR_STACK = !new Error("").stack;
 
@@ -19,13 +19,13 @@ export function getErrorWithStack() {
         // Doing something naughty in strict mode here to trigger a specific error
         // that can be explicitely ignored in debugger's exception settings.
         // If we'd just throw new Error() here, IE's debugger's exception settings
-        // wouldn't let us explicitely ignore those errors.
+        // will just consider it as "exception thrown by javascript code" which is
+        // something you wouldn't want it to ignore.
         getErrorWithStack.arguments;
     } catch(e) {
         return e;
-    } else {
-        return new Error();
     }
+    return new Error();
 }
 
 export function prettyStack(exception, numIgnoredFrames) {

--- a/src/debug.js
+++ b/src/debug.js
@@ -13,11 +13,29 @@ export var libraryFilter = ()=>true;
 
 export const NEEDS_THROW_FOR_STACK = !new Error("").stack;
 
-export function prettyStack(exception, numIgnoredLines) {
+export function getErrorWithStack() {
+    "use strict";
+    if (NEEDS_THROW_FOR_STACK) try {
+        // Doing something naughty in strict mode here to trigger a specific error
+        // that can be explicitely ignored in debugger's exception settings.
+        // If we'd just throw new Error() here, IE's debugger's exception settings
+        // wouldn't let us explicitely ignore those errors.
+        getErrorWithStack.arguments;
+    } catch(e) {
+        return e;
+    } else {
+        return new Error();
+    }
+}
+
+export function prettyStack(exception, numIgnoredFrames) {
     var stack = exception.stack;
     if (!stack) return "";
+    numIgnoredFrames = (numIgnoredFrames || 0);
+    if (stack.indexOf(exception.name) === 0)
+        numIgnoredFrames += (exception.name + exception.message).split('\n').length;
     return stack.split('\n')
-        .slice(numIgnoredLines || 0)
+        .slice(numIgnoredFrames)
         .filter(libraryFilter)
         .map(frame => "\n" + frame)
         .join('');

--- a/src/errors.js
+++ b/src/errors.js
@@ -140,16 +140,14 @@ export var exceptionMap = idbDomErrorNames.reduce((obj, name)=>{
 }, {});
 
 export function mapError (domError, message) {
-    if (!domError) return domError;
-    var rv = domError;
-    if (!(domError instanceof DexieError) && domError.name && exceptionMap[domError.name]) {
-        rv = new exceptionMap[domError.name](message || domError.message, domError);
-        if (!("stack" in domError)) {
-            // Derive stack from inner exception if it has a stack
-            setProp(rv, "stack", {get: function(){
-                return this.inner.stack;
-            }});
-        }
+    if (!domError || domError instanceof DexieError || domError instanceof TypeError || domError instanceof SyntaxError || !domError.name || !exceptionMap[domError.name])
+        return domError;
+    var rv = new exceptionMap[domError.name](message || domError.message, domError);
+    if ("stack" in domError) {
+        // Derive stack from inner exception if it has a stack
+        setProp(rv, "stack", {get: function(){
+            return this.inner.stack;
+        }});
     }
     return rv;
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,4 +1,4 @@
-import { derive } from './utils';
+import { derive, setProp } from './utils';
 
 var dexieErrorNames = [
     'Modify',
@@ -140,9 +140,16 @@ export var exceptionMap = idbDomErrorNames.reduce((obj, name)=>{
 }, {});
 
 export function mapError (domError, message) {
+    if (!domError) return domError;
     var rv = domError;
     if (!(domError instanceof DexieError) && domError.name && exceptionMap[domError.name]) {
         rv = new exceptionMap[domError.name](message || domError.message, domError);
+        if (!("stack" in domError)) {
+            // Derive stack from inner exception if it has a stack
+            setProp(rv, "stack", {get: function(){
+                return this.inner.stack;
+            }});
+        }
     }
     return rv;
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -110,7 +110,10 @@ export var exceptions = errorList.reduce((obj,name)=>{
     var fullName = name + "Error";
     function DexieError (msgOrInner, inner){
         this.name = fullName;
-        if (typeof msgOrInner === 'string') {
+        if (!msgOrInner) {
+            this.message = "Unknown Error";
+            this.inner = null;
+        } else if (typeof msgOrInner === 'string') {
             this.message = msgOrInner;
             this.inner = inner || null;
         } else if (typeof msgOrInner === 'object') {

--- a/src/errors.js
+++ b/src/errors.js
@@ -54,10 +54,14 @@ export function DexieError (name, msg) {
     // 2. It doesn't give us much in this case.
     // 3. It would require sub classes to call super(), which
     //    is not needed when deriving from Error.
+    this._e = new Error(msg); // For stack generation.
     this.name = name;
     this.message = msg;
 }
-derive(DexieError).from(Error);
+derive(DexieError).from(Error).extend({
+    stack: {get: function(){ return this._e.stack.replace("Error:", this.name + ":")}},
+    toString: function(){ return this.name + ": " + this.message; }
+});
 
 function getMultiErrorMessage (msg, failures) {
     return msg + ". Errors: " + failures

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,22 +77,17 @@ export function getUniqueArray(a) {
     return a.filter((value, index, self) => self.indexOf(value) === index);
 }
 
-export function trycatch(fn, reject) {
-    var psd = Promise.PSD;
+export function trycatcher(fn, reject) {
     return function () {
-        var outerPSD = Promise.PSD; // Support Promise-specific data (PSD) in callback calls
-        Promise.PSD = psd;
         try {
             fn.apply(this, arguments);
         } catch (e) {
             reject(e);
-        } finally {
-            Promise.PSD = outerPSD;
         }
     };
 }
 
-export function miniTryCatch(fn, onerror, args) {
+export function tryCatch(fn, onerror, args) {
     try {
         fn.apply(null, args);
     } catch (ex) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,7 +40,7 @@ export function props (proto, extension) {
 }
 
 export function setProp(obj, prop, functionOrGetSet, options) {
-    Object.defineProperty(obj, prop, extend(functionOrGetSet && typeof functionOrGetSet.get === 'function' ?
+    Object.defineProperty(obj, prop, extend(functionOrGetSet && hasOwn(functionOrGetSet, "get") && typeof functionOrGetSet.get === 'function' ?
         {get: functionOrGetSet.get, set: functionOrGetSet.set, configurable: true} :
         {value: functionOrGetSet, configurable: true, writable: true}, options));
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,7 @@ export function extend(obj, extension) {
     return obj;
 }
 
-export function extendProto (proto, extension) {
+export function setProps (proto, extension) {
     if (typeof extension === 'function') extension = extension(Object.getPrototypeOf(proto));
     keys(extension).forEach(key => {
         setProp(proto, key, extension[key]);
@@ -45,7 +45,7 @@ export function derive(Child) {
             Child.prototype = Object.create(Parent.prototype);
             setProp(Child.prototype, "constructor", Child);
             return {
-                extend: extendProto.bind(null, Child.prototype)
+                extend: setProps.bind(null, Child.prototype)
             };
         }
     };

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,7 @@ export function extend(obj, extension) {
     return obj;
 }
 
-export function setProps (proto, extension) {
+export function props (proto, extension) {
     if (typeof extension === 'function') extension = extension(Object.getPrototypeOf(proto));
     keys(extension).forEach(key => {
         setProp(proto, key, extension[key]);
@@ -45,7 +45,7 @@ export function derive(Child) {
             Child.prototype = Object.create(Parent.prototype);
             setProp(Child.prototype, "constructor", Child);
             return {
-                extend: setProps.bind(null, Child.prototype)
+                extend: props.bind(null, Child.prototype)
             };
         }
     };
@@ -95,9 +95,10 @@ export function tryCatch(fn, onerror, args) {
     }
 }
 
-export function fail(err) {
+export function rejection (err, uncaughtHandler) {
     // Get the call stack and return a rejected promise.
-    return Promise.reject(err);
+    var rv = Promise.reject(err);
+    return uncaughtHandler ? rv.uncaught(uncaughtHandler) : rv;
 }
 
 export function getByKeyPath(obj, keyPath) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,24 +73,48 @@ export function asap(fn) {
     if (_global.setImmediate) setImmediate(fn); else setTimeout(fn, 0);
 }
 
-export function miniTryCatch(fn, onerror) {
+export function trycatch(fn, reject) {
+    var psd = Promise.PSD;
+    return function () {
+        var outerPSD = Promise.PSD; // Support Promise-specific data (PSD) in callback calls
+        Promise.PSD = psd;
+        try {
+            fn.apply(this, arguments);
+        } catch (e) {
+            reject(e);
+        } finally {
+            Promise.PSD = outerPSD;
+        }
+    };
+}
+
+export function miniTryCatch(fn, onerror, args) {
     try {
-        fn();
+        fn.apply(null, args);
     } catch (ex) {
         onerror && onerror(ex);
     }
 }
 
-export function messageAndStack (e) {
+/*export function messageAndStack (e) {
     var stack = e && e.stack;
     return stack ?
         stack.indexOf(e+'') > 0 ?
             stack :
         e + ". " + stack :
         e;
+}*/
+
+export function prettyStack(e) {
+    var stack = e.stack;
+    if (!stack) return "";
+    return stack.split('\n')
+        .filter(frame => !/(^Error|dexie\.js|dexie\.min\.js)/.test(frame))
+        .map(frame => "\n" + frame)
+        .join('');
 }
 
-export function stack(error) {
+/*export function stack(error) {
     if (error.stack) return error; // Provided error already has a stack
     try {
         var err = new Error(error.message || error); // In Chrome, stack is generated here.
@@ -101,11 +125,11 @@ export function stack(error) {
         error.stack = e.stack;
     }
     return error;
-}
+}*/
 
 export function fail(err) {
     // Get the call stack and return a rejected promise.
-    return Promise.reject(stack(err));
+    return Promise.reject(err);
 }
 
 export function getByKeyPath(obj, keyPath) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,8 +26,10 @@ export function extend(obj, extension) {
     return obj;
 }
 
+export const getProto = Object.getPrototypeOf;
+
 export function props (proto, extension) {
-    if (typeof extension === 'function') extension = extension(Object.getPrototypeOf(proto));
+    if (typeof extension === 'function') extension = extension(getProto(proto));
     keys(extension).forEach(key => {
         setProp(proto, key, extension[key]);
     });
@@ -49,6 +51,14 @@ export function derive(Child) {
             };
         }
     };
+}
+
+export const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+
+export function getPropertyDescriptor(obj, prop) {
+    var pd = getOwnPropertyDescriptor(obj, prop),
+        proto;
+    return pd || (proto = getProto(obj)) && getPropertyDescriptor (proto, prop);
 }
 
 var _slice = [].slice;

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,6 +73,10 @@ export function asap(fn) {
     if (_global.setImmediate) setImmediate(fn); else setTimeout(fn, 0);
 }
 
+export function getUniqueArray(a) {
+    return a.filter((value, index, self) => self.indexOf(value) === index);
+}
+
 export function trycatch(fn, reject) {
     var psd = Promise.PSD;
     return function () {
@@ -95,37 +99,6 @@ export function miniTryCatch(fn, onerror, args) {
         onerror && onerror(ex);
     }
 }
-
-/*export function messageAndStack (e) {
-    var stack = e && e.stack;
-    return stack ?
-        stack.indexOf(e+'') > 0 ?
-            stack :
-        e + ". " + stack :
-        e;
-}*/
-
-export function prettyStack(e) {
-    var stack = e.stack;
-    if (!stack) return "";
-    return stack.split('\n')
-        .filter(frame => !/(^Error|dexie\.js|dexie\.min\.js)/.test(frame))
-        .map(frame => "\n" + frame)
-        .join('');
-}
-
-/*export function stack(error) {
-    if (error.stack) return error; // Provided error already has a stack
-    try {
-        var err = new Error(error.message || error); // In Chrome, stack is generated here.
-        if (err.stack) { error.stack = err.stack; return error; } // If stack was generated, set it.
-        // No stack. Other browsers only put the stack if we throw the error:
-        throw err;
-    } catch (e) {
-        error.stack = e.stack;
-    }
-    return error;
-}*/
 
 export function fail(err) {
     // Get the call stack and return a rejected promise.
@@ -187,7 +160,7 @@ export function delByKeyPath(obj, keyPath) {
         });
 }
 
-    export function shallowClone(obj) {
+export function shallowClone(obj) {
     var rv = {};
     for (var m in obj) {
         if (obj.hasOwnProperty(m)) rv[m] = obj[m];

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,7 +34,7 @@ export function extendProto (proto, extension) {
 }
 
 export function setProp(obj, prop, functionOrGetSet, options) {
-    Object.defineProperty(obj, prop, extend(typeof functionOrGetSet.get === 'function' ?
+    Object.defineProperty(obj, prop, extend(functionOrGetSet && typeof functionOrGetSet.get === 'function' ?
         {get: functionOrGetSet.get, set: functionOrGetSet.set, configurable: true} :
         {value: functionOrGetSet, configurable: true, writable: true}, options));
 }

--- a/test/dexie-unittest-utils.js
+++ b/test/dexie-unittest-utils.js
@@ -1,6 +1,7 @@
 ﻿import Dexie from 'dexie';
 import {ok, start, asyncTest} from 'QUnit';
 
+//Dexie.debug = "dexie";
 
 var no_optimize = window.no_optimize || window.location.search.indexOf('dontoptimize=true') != -1;
 

--- a/test/dexie-unittest-utils.js
+++ b/test/dexie-unittest-utils.js
@@ -1,9 +1,10 @@
 ﻿import Dexie from 'dexie';
 import {ok, start, asyncTest} from 'QUnit';
 
-//Dexie.debug = "dexie";
+Dexie.debug = window.location.search.indexOf('longstacks=true') !== -1 ? 'dexie' : false;
+if (window.location.search.indexOf('longstacks=tests') !== -1) Dexie.debug = true; // Don't include stuff from dexie.js.
 
-var no_optimize = window.no_optimize || window.location.search.indexOf('dontoptimize=true') != -1;
+var no_optimize = window.no_optimize || window.location.search.indexOf('dontoptimize=true') !== -1;
 
 export function resetDatabase(db) {
     /// <param name="db" type="Dexie"></param>

--- a/test/qunit.js
+++ b/test/qunit.js
@@ -269,11 +269,15 @@ config = {
             tooltip: "If enabled in browsers with WebSQL support (Safari,Chrome or Opera) all indexedDB calls will go through IndexedDBShim with WebSQL as backend"
 	    },
 	    {
-	        
 	        id: "dontoptimize",
 	        label: "Dont optimize tests",
 	        tooltip: "Always delete and recreate the DB between each test"
-	    }
+	    },
+        {
+            id: "longstacks",
+            label: "Long async stacks",
+            tooltip: "Set Dexie.debug=true, turning on long async stacks on all errors (Actually we use Dexie.debug='dexie' so that frames from dexie.js are also included)"
+        }
 	],
 
 	// Set of all modules.

--- a/test/tests-collection.js
+++ b/test/tests-collection.js
@@ -30,6 +30,13 @@ module("collection", {
     }
 });
 
+spawnedTest("and with values", function*(){
+    let array = yield db.users.where("last").inAnyRange([["a","g"],["A","G"]])
+        .and(user => user.username === "dfahlander")
+        .toArray();
+    equal (array.length, 1, "Should find one user with given criteria");
+});
+
 spawnedTest("and with keys", function*(){
     let keys = yield db.users.where("last").inAnyRange([["a","g"],["A","G"]])
         .and(user => user.username === "dfahlander")
@@ -459,7 +466,7 @@ asyncTest("or-issue#15-test", function () {
 
         }).catch(function (err) {
 
-            ok(false, "error:" + err);
+            ok(false, "error:" + err.stack);
 
         }).finally(function () {
             if (--numRuns == 0) {

--- a/test/tests-collection.js
+++ b/test/tests-collection.js
@@ -23,7 +23,7 @@ module("collection", {
     setup: function () {
         stop();
         resetDatabase(db).catch(function (e) {
-            ok(false, "Error resetting database: " + e);
+            ok(false, "Error resetting database: " + e.stack);
         }).finally(start);
     },
     teardown: function () {

--- a/test/tests-crud-hooks.js
+++ b/test/tests-crud-hooks.js
@@ -252,7 +252,7 @@ module("crud-hooks", {
     setup: function () {
         stop();
         resetDatabase(db).then(()=>reset()).catch(e => {
-            ok(false, "Error resetting database: " + e);
+            ok(false, "Error resetting database: " + e.stack);
         }).finally(start);
     },
     teardown: function () {

--- a/test/tests-exception-handling.js
+++ b/test/tests-exception-handling.js
@@ -267,7 +267,7 @@ asyncTest("catch-all with db.on('error')", 6, function () {
     });
     var errorCount = 0;
     ourDB.on("error", function (e) {
-        ok(errorCount < 5, "Uncatched error successfully bubbled to ourDB.on('error'): " + e);
+        ok(errorCount < 5, "Uncatched error successfully bubbled to ourDB.on('error'): " + e.stack);
         if (++errorCount == 5) {
             ourDB.delete().then(()=>{
                 Dexie.Promise.on('error').unsubscribe(swallowPromiseOnError);

--- a/test/tests-exception-handling.js
+++ b/test/tests-exception-handling.js
@@ -18,7 +18,7 @@ module("exception-handling", {
     setup: function () {
         stop();
         resetDatabase(db).catch(function (e) {
-            ok(false, "Error resetting database: " + e);
+            ok(false, "Error resetting database: " + e.stack);
         }).finally(start);
     },
     teardown: function () {
@@ -236,7 +236,7 @@ asyncTest("exception in on('populate')", function () {
     });
     db.open().catch(function (err) {
         // Got error
-        ok(err.toString().indexOf("Oops. Failing in upgrade function") != -1, "Got error: " + err);
+        ok(err.toString().indexOf("Oops. Failing in upgrade function") != -1, "Got error: " + err.stack);
         // Create 3rd instance of db that will only read from the existing DB.
         // What we want to check here is that the DB is there but is still
         // only on version 1.
@@ -244,8 +244,8 @@ asyncTest("exception in on('populate')", function () {
         return db.open();
     }).then(function () {
         ok(false, "The database should not have been created");
-    }).catch(function (err) {
-        ok(err.toString().indexOf("doesnt exist") != -1, "The database doesnt exist");
+    }).catch(err => {
+        ok(err instanceof Dexie.NoSuchDatabaseError, "The database doesnt exist");
     }).finally(function () {
         db.delete().then(start);
     });

--- a/test/tests-extendability.js
+++ b/test/tests-extendability.js
@@ -29,20 +29,23 @@ asyncTest("recursive-pause", function () {
         activities.add({ Oid: "A3", Task: "T2", Tick: 200, Tock: 210, Type: 2 });
     });
 
-    db.delete().then(function () { db.open(); });
+    db.delete().then(()=>{
+        return db.open();
+    }).then(()=>{
         
-    db.transaction("rw", db.activities, db.tasks, function () {
-        Dexie.Promise.newPSD(function () {
-            Dexie.currentTransaction._lock();
-            db.activities.where("Type").equals(2).modify({ Flags: 2 }).finally(function () {
-                Dexie.currentTransaction._unlock();
+        return db.transaction("rw", db.activities, db.tasks, function () {
+            Dexie.Promise.newPSD(function () {
+                Dexie.currentTransaction._lock();
+                db.activities.where("Type").equals(2).modify({ Flags: 2 }).finally(function () {
+                    Dexie.currentTransaction._unlock();
+                });
             });
-        });
-        db.activities.where("Flags").equals(2).count(function (count) {
-            equal(count, 1, "Should have put one entry there now");
-        });
-        db.activities.where("Flags").equals(2).each(function (act) {
-            equal(act.Type, 2, "The entry is correct");
+            db.activities.where("Flags").equals(2).count(function (count) {
+                equal(count, 1, "Should have put one entry there now");
+            });
+            db.activities.where("Flags").equals(2).each(function (act) {
+                equal(act.Type, 2, "The entry is correct");
+            });
         });
 
     }).catch(function (e) {

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -15,7 +15,7 @@ module("misc", {
     setup: () => {
         stop();
         resetDatabase(db).catch(e => {
-            ok(false, "Error resetting database: " + e);
+            ok(false, "Error resetting database: " + e.stack);
         }).finally(start);
     },
     teardown: () => {

--- a/test/tests-open.js
+++ b/test/tests-open.js
@@ -425,6 +425,7 @@ asyncTest("db.close", ()=> {
         ok(e instanceof Dexie.DatabaseClosedError, "Should catch DatabaseClosedError");
         return db.open();
     }).then(()=>{
+        console.log("The call to db.open() completed");
         return db.foo.toArray();
     }).then(res => {
         equal(res.length, 0, "Database re-opened and I got a result from my query");

--- a/test/tests-open.js
+++ b/test/tests-open.js
@@ -434,3 +434,19 @@ asyncTest("db.close", ()=> {
         db.delete().catch(e=>console.error(e)).finally(start);
     });
 });
+
+spawnedTest("db.open several times", 2, function*(){
+    let db = new Dexie("TestDB");
+    db.version(1).stores({foo: "id"});
+    db.on('populate', ()=>{throw "Failed in populate";});
+    db.open().then(()=>{
+        ok(false, "Should not succeed to open");
+    }).catch(err =>{
+        ok(true, "Got error: " + (err.stack || err));
+    });
+    yield db.open().then(()=>{
+        ok(false, "Should not succeed to open");
+    }).catch(err =>{
+        ok(true, "Got error: " + (err.stack || err));
+    });
+});

--- a/test/tests-open.js
+++ b/test/tests-open.js
@@ -268,7 +268,7 @@ asyncTest("Issue #76 Dexie inside Web Worker", function () {
         }).then(function () {
             ok(true, "Transaction committed");
         }).catch(function(err) {
-            ok(false, "Transaction failed");
+            ok(false, "Transaction failed: " + err.stack);
         }).finally(done);
     }
 

--- a/test/tests-open.js
+++ b/test/tests-open.js
@@ -396,7 +396,7 @@ asyncTest("No auto-open", ()=> {
         equal(res.length, 0, "Got an answer now when opened.");
         db.close();
         let openPromise = db.open().then(()=>{
-            debugger;
+            //console.log("Why are we here? " + Dexie.Promise.reject().stack);
             ok(false, "Should not succeed to open because we closed it during the open sequence.")
         }).catch(e=> {
             ok(e instanceof Dexie.DatabaseClosedError, "Got DatabaseClosedError from the db.open() call.");
@@ -408,8 +408,6 @@ asyncTest("No auto-open", ()=> {
         });
         db.close();
         return Promise.all([openPromise, queryPromise]);
-    }).catch(e => {
-        ok(e instanceof Dexie.OpenFailedError);
     }).catch(e => {
         ok(false, e);
     }).finally(start);

--- a/test/tests-open.js
+++ b/test/tests-open.js
@@ -152,9 +152,9 @@ asyncTest("test-if-database-exists", 3, function () {
     });
 });
 
-asyncTest("open database without specifying version or schema", 10, function () {
+asyncTest("open database without specifying version or schema", Dexie.Observable ? 1 : 10, function () {
     if (Dexie.Observable) {
-        ok(false, "Dexie.Observable currently not compatible with this mode");
+        ok(true, "Dexie.Observable currently not compatible with this mode");
         return start();
     }
     var db = new Dexie("TestDB");

--- a/test/tests-promise.js
+++ b/test/tests-promise.js
@@ -80,6 +80,7 @@ asyncTest("Promise.track", ()=>{
 
 asyncTest ("Promise.track chained", ()=>{
     var Promise = Dexie.Promise;
+    //Promise._rootExec(()=>{
     var createdPromises = 0,
         createdPromises2 = 0,
         resolvedPromises = 0,
@@ -90,6 +91,7 @@ asyncTest ("Promise.track chained", ()=>{
     Promise.track(()=>{
         new Promise(resolve => resolve())
             .then(()=>Promise.track(()=>{
+                Promise.PSD.inner = true;
                 new Promise(resolve => resolve())
                     .then(x => 3)
                     .then(null, e => "catched")
@@ -107,10 +109,12 @@ asyncTest ("Promise.track chained", ()=>{
         onreject: p => ++rejectedPromises
     }).then(()=>{
         equal(createdPromises2, 4, "Should be 4 promises in inner scope");
-        equal(createdPromises2, rejectedPromises2 + resolvedPromises2, "created and rejected/resolved must be same");
+        equal(resolvedPromises2, 4, "Should be 4 resolved promises in inner scope");
+        equal(rejectedPromises2 + resolvedPromises2, createdPromises2, "created and (rejected + resolved) must be same");
         equal(createdPromises, 7, "Should be 7 promises in outmost scope");
         start();
     });
+    //});
 });
 
 asyncTest("Promise.on.error should propagate once", 1, function(){

--- a/test/tests-promise.js
+++ b/test/tests-promise.js
@@ -283,3 +283,87 @@ asyncTest("Issue #97 A transaction may be lost after calling Dexie.Promise.resol
     });
 });
 
+/*asyncTest("setTimeout vs setImmediate", ()=>{
+    var log=[];
+    setImmediate(()=>{
+        log.push("setImmediate");
+        if (log.length == 2) end();
+    });
+    setTimeout(()=>{
+        log.push("setTimeout");
+        if (log.length == 2) end();
+    }, 40);
+    function end() {
+        equal(log[0], "setImmediate", "setImmediate first");
+        equal(log[1], "setTimeout", "setTimeout second");
+        start();
+    }
+});*/
+
+asyncTest("Promise.on.error", ()=> {
+    var errors = [];
+    function onError(e, p) {
+        errors.push(e);
+        return false;
+    }
+    Dexie.Promise.on('error', onError);
+    
+    new Dexie.Promise((resolve, reject) => {
+        reject ("error");
+    });
+    setTimeout(()=>{
+        equal(errors.length, 1, "Should be one error there");
+        equal(errors[0], "error", "Should be our error there");
+        Dexie.Promise.on.error.unsubscribe(onError);
+        start();
+    }, 40);
+});
+
+asyncTest("Promise.on.error2", ()=> {
+    var errors = [];
+    function onError(e, p) {
+        errors.push(e);
+        return false;
+    }
+    Dexie.Promise.on('error', onError);
+    
+    new Dexie.Promise((resolve, reject) => {
+        new Dexie.Promise((resolve2, reject2) => {
+            reject2 ("error");
+        }).then(resolve, e => {
+            reject(e);
+            //return Dexie.Promise.reject(e);
+        });
+    });
+    
+    setTimeout(()=>{
+        equal(errors.length, 1, "Should be one error there");
+        equal(errors[0], "error", "Should be our error there");
+        Dexie.Promise.on.error.unsubscribe(onError);
+        start();
+    }, 40);
+});
+
+asyncTest("Promise.on.error3", ()=> {
+    var errors = [];
+    function onError(e, p) {
+        errors.push(e);
+        return false;
+    }
+    Dexie.Promise.on('error', onError);
+    
+    new Dexie.Promise((resolve, reject) => {
+        new Dexie.Promise((resolve2, reject2) => {
+            reject2 ("error");
+        }).then(resolve, e => {
+            reject(e);
+            //return Dexie.Promise.reject(e);
+        });
+    }).catch(()=>{});
+    
+    setTimeout(()=>{
+        equal(errors.length, 0, "Should be zarro errors there");
+        Dexie.Promise.on.error.unsubscribe(onError);
+        start();
+    }, 40);
+});

--- a/test/tests-table.js
+++ b/test/tests-table.js
@@ -655,3 +655,13 @@ asyncTest("clear", function () {
         ok(false, e);
     }).finally(start);
 });
+
+spawnedTest("failReadonly", function*(){
+    db.transaction('r', 'users', function*() {
+        yield db.users.bulkAdd([]);
+    }).then(()=>{
+        ok(false, "Should not happen");
+    }).catch ('ReadOnlyError', e => {
+        ok(true, "Got ReadOnlyError: " + e.stack);
+    });
+});

--- a/test/tests-table.js
+++ b/test/tests-table.js
@@ -657,11 +657,32 @@ asyncTest("clear", function () {
 });
 
 spawnedTest("failReadonly", function*(){
-    db.transaction('r', 'users', function*() {
+    yield db.transaction('r', 'users', function*() {
         yield db.users.bulkAdd([{first: "Foo", last: "Bar"}]);
     }).then(()=>{
         ok(false, "Should not happen");
     }).catch ('ReadOnlyError', e => {
         ok(true, "Got ReadOnlyError: " + e.stack);
     });
+});
+
+spawnedTest("failNotIncludedStore", function*(){
+    yield db.transaction('rw', 'folks', function*() {
+        yield db.users.bulkAdd([{first: "Foo", last: "Bar"}]);
+    }).then(()=>{
+        ok(false, "Should not happen");
+    }).catch ('NotFoundError', e => {
+        ok(true, "Got NotFoundError: " + e.stack);
+    });
+});
+
+asyncTest("failNotIncludedStoreTrans", () => {
+    db.transaction('rw', 'foodassaddas', ()=>{
+    }).then(()=>{
+        ok(false, "Should not happen");
+    }).catch ('NotFoundError', e => {
+        ok(true, "Got NotFoundError: " + e.stack);
+    }).catch (e => {
+        ok(false, "Oops: " + e.stack);
+    }).then(start);
 });

--- a/test/tests-table.js
+++ b/test/tests-table.js
@@ -658,7 +658,7 @@ asyncTest("clear", function () {
 
 spawnedTest("failReadonly", function*(){
     db.transaction('r', 'users', function*() {
-        yield db.users.bulkAdd([]);
+        yield db.users.bulkAdd([{first: "Foo", last: "Bar"}]);
     }).then(()=>{
         ok(false, "Should not happen");
     }).catch ('ReadOnlyError', e => {

--- a/test/tests-table.js
+++ b/test/tests-table.js
@@ -32,7 +32,7 @@ module("table", {
     setup: function () {
         stop();
         resetDatabase(db).catch(function (e) {
-            ok(false, "Error resetting database: " + e);
+            ok(false, "Error resetting database: " + e.stack);
         }).finally(start);
     },
     teardown: function () {

--- a/test/tests-transaction.js
+++ b/test/tests-transaction.js
@@ -733,7 +733,7 @@ asyncTest("Issue #137 db.table() does not respect current transaction", function
     }).finally(start);
 });
 
-asyncTest("Dexie.currentTransaction in CRUD hooks", 55, function () {
+asyncTest("Dexie.currentTransaction in CRUD hooks", 53, function () {
 
     function CurrentTransChecker(scope, trans) {
         return function() {

--- a/test/tests-transaction.js
+++ b/test/tests-transaction.js
@@ -334,8 +334,10 @@ asyncTest("'!' mode: Transaction bound to different db instance", function () {
         pets: "++id,kind",
         petsPerUser: "++,user,pet"
     });
-    db2.open();
-    db.transaction('rw', "users", "pets", function () {
+    
+    db2.delete()
+    .then(()=>db2.open())
+    .then(()=>db.transaction('rw', "users", "pets", function () {
         db2.transaction('rw!', "users", "pets", function () {
             ok(true, "Possible to enter a transaction in db2");
         }).catch(function (err) {
@@ -344,7 +346,7 @@ asyncTest("'!' mode: Transaction bound to different db instance", function () {
             if (++counter == 2) db2.delete().then(start);
             console.log("finally() in db2.transaction(). counter == " + counter);
         });
-    }).finally(function () {
+    })).finally(function () {
         if (++counter == 2) db2.delete().then(start);
         console.log("finally() in db.transaction(). counter == " + counter);
     });

--- a/test/tests-transaction.js
+++ b/test/tests-transaction.js
@@ -70,7 +70,7 @@ asyncTest("Table not in transaction", function () {
         }).then(function () {
             ok(false, "Transaction should not commit because I made an error");
         }).catch(function (err) {
-            ok(true, "Got error since we tried using a table not in transaction: " + err);
+            ok(true, "Got error since we tried using a table not in transaction: " + err.stack);
         });
     }).finally(start);
 });
@@ -81,7 +81,7 @@ asyncTest("Table not in transaction 2", function () {
     }).then(function () {
     ok(false, "Transaction should not commit because I made an error");
     }).catch(function (err) {
-    ok(true, "Got error since we tried using a table not in transaction: " + err);
+    ok(true, "Got error since we tried using a table not in transaction: " + err.stack);
     }).finally(start);
 });
 
@@ -93,7 +93,7 @@ asyncTest("Write into readonly transaction", function () {
     }).then(function () {
         ok(false, "Transaction should not commit because I made an error");
     }).catch(function (err) {
-        ok(true, "Got error since we tried to write to users when in a readonly transaction: " + err);
+        ok(true, "Got error since we tried to write to users when in a readonly transaction: " + err.stack);
     }).finally(start);
 });
 
@@ -119,7 +119,7 @@ asyncTest("Inactive transaction", function () {
     }).then(function () {
         ok(false, "Should not be able to get a here transaction has become inactive");
     }).catch(function (err) {
-        ok(true, "Got error because the transaction has already committed: " + err);
+        ok(true, "Got error because the transaction has already committed: " + err.stack);
     }).finally(start);
 });
 
@@ -145,7 +145,7 @@ asyncTest("Inactive transaction 2", function () {
     }).then(function () {
         ok(false, "Should not be able to get a here transaction has become inactive");
     }).catch(function (err) {
-        ok(true, "Got error because the transaction has already committed: " + err);
+        ok(true, "Got error because the transaction has already committed: " + err.stack);
     }).finally(start);
 });
 

--- a/test/tests-transaction.js
+++ b/test/tests-transaction.js
@@ -189,6 +189,7 @@ asyncTest("sub-transactions", function () {
         });
     }).then(function (retval) {
         equal(retval, "hello...", "Return value went all the way down to transaction resolvance");
+        ok(Dexie.currentTransaction == null, "Dexie.currentTransaction is null");
         db.users.count(function (count) { // Transaction-less operation!
             equal(count, 5, "There are five users in db");
         });
@@ -217,6 +218,8 @@ asyncTest("sub-transactions", function () {
             });
             //});
         }).catch("ConstraintError", function (err) {
+            // Yes, it should fail beause of limited rollback support on nested transactions:
+            // https://github.com/dfahlander/Dexie.js/wiki/Dexie.transaction()#limitations-with-nested-transactions
             ok(true, "Got constraint error on outer transaction as well");
         });
     }).catch(function (err) {

--- a/test/tests-whereclause.js
+++ b/test/tests-whereclause.js
@@ -85,7 +85,7 @@ module("WhereClause", {
     setup: function () {
         stop();
         resetDatabase(db).catch(function (e) {
-            ok(false, "Error resetting database: " + e);
+            ok(false, "Error resetting database: " + e.stack);
         }).finally(start);
     },
     teardown: function () {

--- a/test/tests-yield.js
+++ b/test/tests-yield.js
@@ -15,7 +15,7 @@ module("yield", {
     setup: function () {
         stop();
         resetDatabase(db).catch(function (e) {
-            ok(false, "Error resetting database: " + e);
+            ok(false, "Error resetting database: " + e.stack);
         }).finally(start);
     },
     teardown: function () {


### PR DESCRIPTION
The result of some weeks of refactoring.
The main issue was that Dexie.Promise were:

1. Executing then-handlers in long call stacks making it hard to debug when error occur
2. Uncaught rejections where not possible to detect if direct exceptions had occurred in the constructor of a Promise.
3. Dexie needed to adjust to these limitations of the Promise class - to manually catch direct exceptions and abort the transaction directly - which made large amounts of the Dexie code mysterious and hard to understand the reason behind.

I also took the chance to simplify lots of code in Dexie, like db.open() and runUpgraders(). Now you don't have to step on your toes when dealing with promises anymore.

Optimized Promise class as much as possible and made it support long asyncronic stacks when in debug mode (which is now the default mode when served from localhost. Can be changed using Dexie.debug = false / Dexie.debug = true).
