### PR TITLE
Updated info on how to get long stack support when using Electron.

### DIFF
--- a/samples/electron/index.html
+++ b/samples/electron/index.html
@@ -4,6 +4,8 @@
   <script>
     // Import Dexie
     const Dexie = require('dexie');
+    // Force debug mode to get long stacks from exceptions.
+    Dexie.debug = true; // In production, set to false to increase performance a little.
 
     //
     // Declare Database
@@ -29,7 +31,7 @@
         alert ("My young friends: " + JSON.stringify(youngFriends));
 
     }).catch(e => {
-        alert(e);
+        console.error (e.stack);
     });    
   </script>
  </head>

--- a/samples/electron/package.json
+++ b/samples/electron/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "dexie": "^1.3.6",
+    "dexie": "^1.4.0-rc.1",
     "electron-prebuilt": "^1.2.1"
   }
 }


### PR DESCRIPTION
In web pages, long stacks are automatically turned on when served from localhost. But electron apps are served from file:///, and there's no way for Dexie to tell whether this is a production or development environment.

The sample shows how to force debug mode, which is really a good thing while developing your app.

Also updated dependency to latest dexie with support for long stacks.