### PR TITLE
Confirm table deletion

### DIFF
--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -300,7 +300,7 @@ export default function Dexie(dbName, options) {
                 }
             });
             queue.push(function (idbtrans) {
-                if (anyContentUpgraderHasRun && !hasIEDeleteObjectStoreBug) { // Dont delete old tables if ieBug is present and a content upgrader has run. Let tables be left in DB so far. This needs to be taken care of.
+                if (!anyContentUpgraderHasRun || !hasIEDeleteObjectStoreBug) { // Dont delete old tables if ieBug is present and a content upgrader has run. Let tables be left in DB so far. This needs to be taken care of.
                     var newSchema = version._cfg.dbschema;
                     // Delete old tables
                     deleteRemovedTables(newSchema, idbtrans);

--- a/test/tests-upgrading.js
+++ b/test/tests-upgrading.js
@@ -148,6 +148,10 @@ asyncTest("upgrade", function () {
         db.version(8).stores({ store1: null }); // Deleting a version.
         return db.open();
     }).then(function () {
+        // Let Dexie determine actual IDB state 
+        db = new Dexie(DBNAME);
+        return db.open();
+    }).then(function () {
         ok(true, "Could upgrade to version 8 - deleting an object store");
         equal(db.tables.length, baseNumberOfTables + 1, "There should only be 1 store now");
 


### PR DESCRIPTION
It looks like Dexie doesn't remove the underlying IDB object store on upgrade unless an upgrader function runs. I updated the relevant test so it correctly identified that `store1` was still present in the backing IDB and updated the check that was causing the deletion to not occur.