### PR TITLE
Make pull-requests build without browserstack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
+addons:
+  - firefox: "47.0"
 language: node_js
 node_js:
   - "6"
   - "4"
-addons:
-  - firefox: "47.0"
 matrix:
   fast_finish: true
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "6"
   - "4"
 addons:
-  - firefox: "latest"
+  - firefox: "47.0"
 matrix:
   fast_finish: true
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-addons:
-  - firefox: "47.0"
 language: node_js
+addons:
+  firefox: "47.0"
 node_js:
   - "6"
   - "4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ addons:
   - firefox: "latest"
 matrix:
   fast_finish: true
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 script:
   - eslint src
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "6"
-  - "5"
   - "4"
 addons:
   - firefox: "latest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "6"
   - "5"
   - "4"
+addons:
+  - firefox: "latest"
 matrix:
   fast_finish: true
 script:

--- a/test/karma.travis.conf.js
+++ b/test/karma.travis.conf.js
@@ -9,7 +9,10 @@ module.exports = function(config) {
       username: process.env.BROWSER_STACK_USERNAME,
       accessKey: process.env.BROWSER_STACK_ACCESS_KEY
   };
-  if (!cfg.browserStack.username)
+  
+  var isPullRequest = process.env.TRAVIS_PULL_REQUEST !== 'false';
+  
+  if (!isPullRequest && !cfg.browserStack.username)
     throw new Error("You must provider username/key in the env variables BROWSER_STACK_USERNAME and BROWSER_STACK_ACCESS_KEY");
 
   cfg.customLaunchers = {
@@ -22,16 +25,15 @@ module.exports = function(config) {
     },
   };
 
-  cfg.browsers = [
-    //'Firefox'
-    'bs_firefox',
+  cfg.browsers = isPullRequest ? ['Firefox'] :
+    ['bs_firefox']
   ];
 
   cfg.plugins = [
       'karma-qunit',
       'karma-mocha-reporter',
       'karma-browserstack-launcher'
-      //'karma-firefox-launcher'
+      'karma-firefox-launcher'
   ];
 
   config.set(cfg);

--- a/test/karma.travis.conf.js
+++ b/test/karma.travis.conf.js
@@ -25,8 +25,8 @@ module.exports = function(config) {
     },
   };
 
-  cfg.browsers = isPullRequest ? ['Firefox'] :
-    ['bs_firefox']
+  cfg.browsers = isPullRequest ? ['Firefox'] : [
+    'bs_firefox'
   ];
 
   cfg.plugins = [

--- a/test/karma.travis.conf.js
+++ b/test/karma.travis.conf.js
@@ -32,7 +32,7 @@ module.exports = function(config) {
   cfg.plugins = [
       'karma-qunit',
       'karma-mocha-reporter',
-      'karma-browserstack-launcher'
+      'karma-browserstack-launcher',
       'karma-firefox-launcher'
   ];
 


### PR DESCRIPTION
Browserstack requires encrypted username and key env vars. Travis won't inject encrypted env vars from foreign pull requests resulting in that all pull requests fails. Need to work around this by running unit test locally on the travis server for pull requests but keep browserstack tests for the master branch.