### PR TITLE
Delete table only if new schema explicitly sets it to null

### DIFF
--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -386,7 +386,7 @@ export default function Dexie(dbName, options) {
     function deleteRemovedTables(newSchema, idbtrans) {
         for (var i = 0; i < idbtrans.db.objectStoreNames.length; ++i) {
             var storeName = idbtrans.db.objectStoreNames[i];
-            if (newSchema[storeName] == null) {
+            if (newSchema[storeName] === null) {
                 idbtrans.db.deleteObjectStore(storeName);
             }
         }


### PR DESCRIPTION
The double equal also returns true if a value is undefined. Meaning, if the new schema does not have a table name, we'll delete it. This breaks the "updates-only schema for new versions" pattern recommended by dexie best practices. To fix this, explicitly check for null.