### PR TITLE
When checking parentTrans compatibility, make sure parentTrans is not already null

### DIFF
--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -752,7 +752,7 @@ export default function Dexie(dbName, options) {
                 }
                 if (parentTransaction) {
                     storeNames.forEach(function (storeName) {
-                        if (!hasOwn(parentTransaction.tables, storeName)) {
+                        if (parentTransaction && !hasOwn(parentTransaction.tables, storeName)) {
                             if (onlyIfCompatible) {
                                 // Spawn new transaction instead.
                                 parentTransaction = null; 


### PR DESCRIPTION
forEach() keeps looping through storeNames even if you set parentTransaction to null. Causing an error undefined when we call parentTransaction.tables. Since there's no break in a forEach loop, we just add an additional null check for parentTransaction inside, causing res if the loop iterations to be no-ops.