### PR TITLE
Incorporate all from branch next/v2

### DIFF
--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -458,7 +458,7 @@ export default function Observable(db) {
             Dexie.vip(function() {
                 readChanges(latestRevision).catch('DatabaseClosedError', e=>{
                     // Handle database closed error gracefully while reading changes.
-                    // Don't bubble to db.on.error or Promise.on.error.
+                    // Don't trigger 'unhandledrejection'.
                     // Even though we intercept the close() method, it might be called when in the middle of
                     // reading changes and then that flow will cancel with DatabaseClosedError.
                 });
@@ -539,7 +539,7 @@ export default function Observable(db) {
             readChanges(Observable.latestRevision[db.name]).then(cleanup).then(consumeIntercommMessages)
             .catch('DatabaseClosedError', e=>{
                 // Handle database closed error gracefully while reading changes.
-                // Don't bubble to db.on.error or Promise.on.error.
+                // Don't trigger 'unhandledrejection'.
                 // Even though we intercept the close() method, it might be called when in the middle of
                 // reading changes and then that flow will cancel with DatabaseClosedError.
             })

--- a/addons/Dexie.Syncable/test/tests-syncable.js
+++ b/addons/Dexie.Syncable/test/tests-syncable.js
@@ -50,12 +50,13 @@
 				db1.objects.update(key, {name: "four"});
 			});
 		});
-		db1.on('error', function onError (err) {
-			db1.on('error').unsubscribe(onError);
+		window.addEventListener('unhandledrejection', onError);
+		function onError (err) {
+			window.removeEventListener('unhandledrejection', onError);
 			db1.close();
 			ok(false, err);
 			start();
-		});
+		}
 		db1.syncable.on('statusChanged', function (newStatus) {
 			ok(true, "Status changed to " + Dexie.Syncable.StatusTexts[newStatus]);
 		});

--- a/addons/Dexie.Syncable/test/tests-syncprovider.js
+++ b/addons/Dexie.Syncable/test/tests-syncprovider.js
@@ -72,9 +72,6 @@
         db2.open().then(function () {
             console.log("db2 opened");
         });
-        db2.on.error.subscribe(function (error) {
-            console.error("db2 error: " + error);
-        });
 
         db2.on('changes', function (changes, partial) {
             console.log("db2.on('changes'): changes.length: " + changes.length + "\tpartial: " + (partial ? "true" : "false"));

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "babel-plugin-transform-es2015-block-scoping": "^6.15.0",
     "babel-plugin-transform-es2015-classes": "^6.14.0",
     "babel-plugin-transform-es2015-computed-properties": "^6.6.5",
+    "babel-plugin-transform-es2015-constants": "^6.1.4",
+    "babel-plugin-transform-es2015-destructuring": "^6.16.0",
     "babel-plugin-transform-es2015-literals": "^6.5.0",
     "babel-plugin-transform-es2015-object-super": "^6.6.5",
     "babel-plugin-transform-es2015-parameters": "^6.17.0",

--- a/samples/typescript/src/app.ts
+++ b/samples/typescript/src/app.ts
@@ -24,12 +24,6 @@ document.addEventListener('DOMContentLoaded', async function () {
     // Test it:
     console.log("Hello world!");
 
-    // It's always a good practice to put this listener in the bootstrapping of your app:
-    Dexie.Promise.on.error.subscribe(e => {
-        // Log any uncatched error. In case you forgot to catch something...
-        console.error(e);
-    });
-    
     try {
         //
         // Let's clear and re-seed the database:

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -27,6 +27,8 @@
     "location": false,
     "chrome": false,
     "document": false,
-    "MutationObserver": false
+    "MutationObserver": false,
+    "CustomEvent": false,
+    "dispatchEvent": false
   }
 }

--- a/src/Dexie.d.ts
+++ b/src/Dexie.d.ts
@@ -118,10 +118,8 @@ declare class Dexie {
     Table : new()=>Dexie.Table<any,any>;
     WhereClause: new()=>Dexie.WhereClause<any,any>;
     Version: new()=>Dexie.Version;
-    WriteableTable: new()=>Dexie.Table<any,any>;
     Transaction: new()=>Dexie.Transaction;
     Collection: new()=>Dexie.Collection<any,any>;
-    WriteableCollection: new()=>Dexie.Collection<any,any>;    
 }
 
 declare module Dexie {

--- a/src/Dexie.d.ts
+++ b/src/Dexie.d.ts
@@ -434,7 +434,6 @@ declare module Dexie {
     class UnsupportedError extends DexieError {constructor (msg?: string, inner?: Object);	constructor (inner: Object);}
     class InternalError extends DexieError {constructor (msg?: string, inner?: Object);	constructor (inner: Object);}
     class DatabaseClosedError extends DexieError {constructor (msg?: string, inner?: Object);	constructor (inner: Object);}
-    class IncompatiblePromiseError extends DexieError {constructor (msg?: string, inner?: Object);	constructor (inner: Object);}
     class UnknownError extends DexieError {constructor (msg?: string, inner?: Object);	constructor (inner: Object);}
     class ConstraintError extends DexieError {constructor (msg?: string, inner?: Object);	constructor (inner: Object);}
     class DataError extends DexieError {constructor (msg?: string, inner?: Object);	constructor (inner: Object);}

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -696,6 +696,26 @@ export default function Dexie(dbName, options) {
         db.on("populate").fire(db._createTransaction(READWRITE, dbStoreNames, globalSchema));
         db.on("error").fire(new Error());
     });
+    
+    this.tranx = function (mode, tableInstances, scopeFunc) {
+        var l = arguments.length,
+            args = new Array(l),
+            i = l;
+        while (i--) args[i] = arguments[i];
+        var func = args[l-1];
+        args[l-1] = function () {
+            PSD.onenter = function () {
+                this.Promise = _global.Promise;
+                _global.Promise = Promise;
+            }
+            PSD.onleave = function () {
+                _global.Promise = this.Promise;
+            }
+            PSD.onenter();
+            return func.call(this, this); // Give transaction as first argument instead of table instances.
+        };
+        return this.transaction.apply(this, args);
+    }
 
     this.transaction = function (mode, tableInstances, scopeFunc) {
         /// <summary>

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -697,7 +697,7 @@ export default function Dexie(dbName, options) {
         db.on("error").fire(new Error());
     });
     
-    this.tranx = function (mode, tableInstances, scopeFunc) {
+    this.tranx = function () {
         var l = arguments.length,
             args = new Array(l),
             i = l;
@@ -715,7 +715,7 @@ export default function Dexie(dbName, options) {
                 this.Promise = _global.Promise;
                 _global.Promise = Promise;
                 return true;
-            };
+            }
             
             function onleave () {
                 _global.Promise = this.Promise;

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -3055,7 +3055,6 @@ props(Dexie, {
     override: override,
     // Export our Events() function - can be handy as a toolkit
     Events: Events,
-    events: Events, // Backward compatible lowercase version. Deprecate.
     // Utilities
     getByKeyPath: getByKeyPath,
     setByKeyPath: setByKeyPath,

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -1484,28 +1484,8 @@ export default function Dexie(dbName, options) {
         abort: function () {
             this.active && this._reject(new exceptions.Abort());
             this.active = false;
-        },
-        
-        tables: {
-            get: Debug.deprecated ("Transaction.tables", function () {
-                return arrayToObject(this.storeNames, name => [name, allTables[name]]);
-            }, "Use db.tables()")
-        },
-
-        complete: Debug.deprecated ("Transaction.complete()", function (cb) {
-            return this.on("complete", cb);
-        }),
-        
-        error: Debug.deprecated ("Transaction.error()", function (cb) {
-            return this.on("error", cb);
-        }),
-        
-        table: Debug.deprecated ("Transaction.table()", function (name) {
-            if (this.storeNames.indexOf(name) === -1)
-                throw new exceptions.InvalidTable("Table " + name + " not in transaction");
-            return allTables[name];
-        })
-        
+        }
+                
     });
 
     //

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -709,8 +709,8 @@ export default function Dexie(dbName, options) {
         /// <param name="tableInstances">Table instance, Array of Table instances, String or String Array of object stores to include in the transaction</param>
         /// <param name="scopeFunc" type="Function">Function to execute with transaction</param>
 
-        var [mode, tables, scopeFunc] = extractTransactionArgs.apply(null, arguments);
-        return this._transaction.call (this, mode, tables, function(){return scopeFunc.call(this, this);}, {pgp: true});
+        var args = extractTransactionArgs.apply(null, arguments);
+        return this._transaction.call (this, args[0], args[1], function(){return args[2].call(this, this);}, {pgp: true});
     }
     
     this.transaction = function () {

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -1470,8 +1470,13 @@ export default function Dexie(dbName, options) {
         abort: function () {
             this.active && this._reject(new exceptions.Abort());
             this.active = false;
-        }
-                
+        },
+
+        tables: {
+            get: Debug.deprecated ("Transaction.tables", ()=>allTables)
+        },
+
+        table: Debug.deprecated ("Transaction.table()", name => allTables[name])
     });
 
     //

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -697,7 +697,7 @@ export default function Dexie(dbName, options) {
         db.on("error").fire(new Error());
     });
     
-    this.tranx = function (mode, _tableArgs_, scopeFunc) {
+    this.tranx = function () {
         /// <summary>
         ///     Start an IndexedDB transaction and enter a zone where global Promise is being
         ///     temporarly patched to work with async / await:
@@ -714,7 +714,7 @@ export default function Dexie(dbName, options) {
         return this._transaction.apply (this, args);
     }
     
-    this.transaction = function (mode, _tableArgs_, scopeFunc) {
+    this.transaction = function () {
         /// <summary>
         ///
         /// </summary>

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -605,8 +605,6 @@ export function newScope (fn, a1, a2, a3) {
     psd.parent = parent;
     psd.ref = 0;
     psd.global = false;
-    psd.onenter = null;
-    psd.onleave = null;
     
     // unhandleds and onunhandled should not be specifically set here.
     // Leave them on parent prototype.

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -1,4 +1,4 @@
-import {doFakeAutoComplete, tryCatch, props, derive,
+import {doFakeAutoComplete, tryCatch, props,
         setProp, _global, getPropertyDescriptor, getArrayOf, extend} from './utils';
 import {reverseStoppableEventChain, nop, callBoth, mirror} from './chaining-functions';
 import Events from './Events';
@@ -174,9 +174,7 @@ export default function Promise(fn) {
     executePromiseTask(this, fn);
 }
 
-// Make this Promise virtually derive from global Promise (extension methods on global promise should extend Dexie.Promise)
-if (Object.setPrototypeOf && _global.Promise) Object.setPrototypeOf(Promise, _global.Promise);
-derive (Promise).from(_global.Promise || Object).extend ({
+props(Promise.prototype, {
 
     then: function (onFulfilled, onRejected) {
         var rv = new Promise((resolve, reject) => {
@@ -693,7 +691,7 @@ function enqueueNativeMicroTask (job) {
     nativePromiseThen.call(resolvedNativePromise, job);
 }
 
-function nativeAwaitCompatibleWrap(fn, zone, possibleAwait, isReject) {
+function nativeAwaitCompatibleWrap(fn, zone, possibleAwait) {
     return typeof fn !== 'function' ? fn : function () {
         var outerZone = PSD;
         switchToZone(zone);

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -722,8 +722,12 @@ function globalError(err, promise) {
             event = new CustomEvent(UNHANDLEDREJECTION, {detail: eventData});
             extend(event, eventData);
         }
-        if (event && _global.dispatchEvent) dispatchEvent(event);
-        else console.warn(`Unhandled rejection: ${e.stack || e}`);
+        if (event && _global.dispatchEvent) {
+            dispatchEvent(event);
+        }
+        if (!event.defaultPrevented) {
+            console.warn(`Unhandled rejection: ${err.stack || err}`);
+        }
     } catch (e) {}
 }
 

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -1,6 +1,6 @@
 import {doFakeAutoComplete, tryCatch, props,
         setProp, _global, getPropertyDescriptor, getArrayOf, extend} from './utils';
-import {reverseStoppableEventChain, nop, callBoth, mirror} from './chaining-functions';
+import {nop, callBoth, mirror} from './chaining-functions';
 import {debug, prettyStack, getErrorWithStack} from './debug';
 
 //

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -303,7 +303,7 @@ props (Promise, {
                     });
                 }, psd.finalize);
                 fn();
-            }, resolve, reject);
+            }, null, resolve, reject);
         });
     },
 
@@ -599,7 +599,7 @@ export function wrap (fn, errorCatcher) {
     };
 }
     
-export function newScope (fn, props) {
+export function newScope (fn, props, a1, a2) {
     var parent = PSD,
         psd = Object.create(parent);
     psd.parent = parent;
@@ -615,7 +615,7 @@ export function newScope (fn, props) {
     psd.finalize = function () {
         --this.parent.ref || this.parent.finalize();
     }
-    var rv = usePSD (psd, fn, a1, a2, a3);
+    var rv = usePSD (psd, fn, a1, a2);
     if (psd.ref === 0) psd.finalize();
     return rv;
 }

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -96,6 +96,7 @@ export var globalPSD = {
     onunhandled: globalError,
     onenter: null,
     onleave: null,
+    tranx: false,
     //env: null, // Will be set whenever leaving a scope using wrappers.snapshot()
     finalize: function () {
         this.unhandleds.forEach(uh => {
@@ -635,6 +636,37 @@ export function usePSD (psd, fn, a1, a2, a3) {
             outerScope.onenter && outerScope.onenter();
         }
     }
+}
+
+function patchGlobalPromise (psd) {
+    let GlobalPromise = _global.Promise,
+        GlobalPromiseProto = GlobalPromise.prototype;
+    psd.GP = GlobalPromise;
+    psd.GPthen = getOwnPropertyDescriptor (GlobalPromiseProto, 'then');
+    _global.Promise = Promise;
+    defineProperty(GlobalPromiseProto, 'then', {get: function(){
+        var psd = PSD;
+        return function () {
+            function proxy (x) {
+                
+            }
+            if (psd === PSD) {
+                arguments[0] = arguments[1] = proxy;
+            }
+            return origThen.apply(this, arguments);
+            return psd === PSD ?
+                try {
+                    
+                } finally {
+                    
+                }
+        };
+    }, configurable: true});
+}
+
+function restoreGlobalPromise (psd) {
+    _global.Promise = psd.Promise;
+    Object.defineProperty(NativePromiseProto, 'then', psd.nthen);
 }
 
 function globalError(err, promise) {

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -101,7 +101,7 @@ var asap = function (callback, args) {
 
 var isOutsideMicroTick = true, // True when NOT in a virtual microTick.
     needsNewPhysicalTick = true, // True when a push to microtickQueue must also schedulePhysicalTick()
-    unhandledErrors = [], // Rejected promises that has occured. Used for firing Promise.on.error and promise.onuncatched.
+    unhandledErrors = [], // Rejected promises that has occured. Used for triggering 'unhandledrejection'.
     rejectingErrors = [], // Tracks if errors are being re-rejected during onRejected callback.
     currentFulfiller = null,
     rejectionMapper = mirror; // Remove in next major when removing error mapping of DOMErrors and DOMExceptions

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -168,7 +168,7 @@ props(Promise.prototype, {
     
     _then: function (onFulfilled, onRejected) {
         // A little tinier version of then() that don't have to create a resulting promise.
-        propagateToListener(this, new Listener(null, null, onFulfilled, onRejected));        
+        propagateToListener(this, new Listener(null, null, onFulfilled, onRejected, PSD));        
     },
 
     catch: function (onRejected) {
@@ -234,8 +234,8 @@ function Listener(onFulfilled, onRejected, resolve, reject, zone) {
     this.onRejected = typeof onRejected === 'function' ? onRejected : null;
     this.resolve = resolve;
     this.reject = reject;
-    this.psd = zone;
-    this.possibleAwait = zone !== PSD;
+    this.psd = zone.pgp ? zone : PSD;
+    this.possibleAwait = zone.pgp && zone !== PSD;
 }
 
 // Promise Static Properties

--- a/src/errors.js
+++ b/src/errors.js
@@ -15,8 +15,7 @@ var dexieErrorNames = [
     'SubTransaction',
     'Unsupported',
     'Internal',
-    'DatabaseClosed',
-    'IncompatiblePromise'
+    'DatabaseClosed'
 ];
 
 var idbDomErrorNames = [

--- a/src/errors.js
+++ b/src/errors.js
@@ -76,7 +76,7 @@ function getMultiErrorMessage (msg, failures) {
 }
 
 //
-// ModifyError - thrown in WriteableCollection.modify()
+// ModifyError - thrown in Collection.modify()
 // Specific constructor because it contains members failures and failedKeys.
 //
 export function ModifyError (msg, failures, successCount, failedKeys) {

--- a/src/promise-utils.js
+++ b/src/promise-utils.js
@@ -1,7 +1,0 @@
-import Promise from './Promise';
-
-export function rejection (err, uncaughtHandler) {
-    // Get the call stack and return a rejected promise.
-    var rv = Promise.reject(err);
-    return uncaughtHandler ? rv.uncaught(uncaughtHandler) : rv;
-}

--- a/src/utils.js
+++ b/src/utils.js
@@ -36,8 +36,10 @@ export function props (proto, extension) {
     });
 }
 
+export const defineProperty = Object.defineProperty;
+
 export function setProp(obj, prop, functionOrGetSet, options) {
-    Object.defineProperty(obj, prop, extend(functionOrGetSet && hasOwn(functionOrGetSet, "get") && typeof functionOrGetSet.get === 'function' ?
+    defineProperty(obj, prop, extend(functionOrGetSet && hasOwn(functionOrGetSet, "get") && typeof functionOrGetSet.get === 'function' ?
         {get: functionOrGetSet.get, set: functionOrGetSet.set, configurable: true} :
         {value: functionOrGetSet, configurable: true, writable: true}, options));
 }

--- a/test/dexie-unittest-utils.js
+++ b/test/dexie-unittest-utils.js
@@ -118,13 +118,13 @@ export function spawnedTest (name, num, promiseGenerator) {
         asyncTest(name, function(){
             Dexie.spawn(promiseGenerator)
                 .catch(e => ok(false, e.stack || e))
-                .finally(start);
+                .then(start);
         });
     } else {
         asyncTest(name, num, function(){
             Dexie.spawn(promiseGenerator)
                 .catch(e => ok(false, e.stack || e))
-                .finally(start);
+                .then(start);
         });
     }
 }

--- a/test/karma.release.conf.js
+++ b/test/karma.release.conf.js
@@ -13,6 +13,13 @@ module.exports = function(config) {
     throw new Error("You must provider username/key in the env variables BROWSER_STACK_USERNAME and BROWSER_STACK_ACCESS_KEY");
 
   cfg.customLaunchers = {
+    bs_firefox_latest: {
+      base: 'BrowserStack',
+      browser: 'firefox',
+      browser_version: 'latest',
+      os: 'Windows',
+      os_version: 7
+    },
     bs_firefox: {
       base: 'BrowserStack',
       browser: 'firefox',
@@ -27,19 +34,36 @@ module.exports = function(config) {
       os: 'Windows',
       os_version: '10'
     },
+    bs_ie11: {
+      base: 'BrowserStack',
+      browser: 'ie',
+      browser_version: '11',
+      os: 'Windows',
+      os_version: 7
+    },
     bs_chrome: {
       base: 'BrowserStack',
       browser: "Chrome",
       browser_version: "49",
       os: 'OS X',
       os_version: 'Mountain Lion'
+    },
+    bs_chrome_latest: {      
+      base: 'BrowserStack',
+      browser: "Chrome",
+      browser_version: "latest",
+      os: 'Windows',
+      os_version: 10
     }
   };
 
   cfg.browsers = [
     'bs_chrome',
+    'bs_chrome_latest',
     'bs_firefox',
-    'bs_edge'
+    'bs_firefox_latest',
+    'bs_edge',
+    'bs_ie11'
   ];
 
   cfg.plugins = [

--- a/test/karma.travis.conf.js
+++ b/test/karma.travis.conf.js
@@ -23,10 +23,18 @@ module.exports = function(config) {
       os: 'Windows',
       os_version: '10'
     },
+    bs_ie11: {
+      base: 'BrowserStack',
+      browser: 'ie',
+      browser_version: '11',
+      os: 'Windows',
+      os_version: 7
+    }
   };
 
   cfg.browsers = !useBrowserStack ? ['Firefox'] : [
-    'bs_firefox'
+    'bs_firefox',
+    'bs_ie11'
   ];
 
   cfg.plugins = [

--- a/test/tests-all.js
+++ b/test/tests-all.js
@@ -7,6 +7,7 @@ import "./tests-table.js";
 import "./tests-extendability.js";
 import "./tests-promise.js";
 import "./tests-transaction.js";
+import "./tests-tranx.js";
 import "./tests-open.js";
 import "./tests-exception-handling.js";
 import "./tests-upgrading.js";

--- a/test/tests-all.js
+++ b/test/tests-all.js
@@ -7,7 +7,7 @@ import "./tests-table.js";
 import "./tests-extendability.js";
 import "./tests-promise.js";
 import "./tests-transaction.js";
-import "./tests-tranx.js";
+import "./tests-asyncawait.js";
 import "./tests-open.js";
 import "./tests-exception-handling.js";
 import "./tests-upgrading.js";

--- a/test/tests-exception-handling.js
+++ b/test/tests-exception-handling.js
@@ -25,13 +25,12 @@ asyncTest("Uncaught promise should signal 'unhandledrejection'", function(){
     var onErrorSignals = 0;
     function onerror(ev) {
         ++onErrorSignals;
+        ev.preventDefault();
     }
-    //Dexie.Promise.on('error', onerror);
     window.addEventListener('unhandledrejection', onerror);
     db.users.add({ id: 1 });
     setTimeout(()=> {
-        equal(onErrorSignals, 1, "Promise.on('error') should have been signaled");
-        //Dexie.Promise.on('error').unsubscribe(onerror);
+        equal(onErrorSignals, 1, "unhandledrejection should have been signaled");
         window.removeEventListener('unhandledrejection', onerror);
         start();
     }, 100);
@@ -400,7 +399,6 @@ asyncTest("Issue #69 Global exception handler for promises", function () {
         ev.preventDefault();
     }
 
-    //Dexie.Promise.on("error", globalRejectionHandler);
     window.addEventListener('unhandledrejection', globalRejectionHandler);
         
     // The most simple case: Any Promise reject that is not catched should
@@ -467,7 +465,6 @@ asyncTest("Issue #69 Global exception handler for promises", function () {
                 equal(errorList[4], "forth error (uncatched but with finally)", "forth error (uncatched but with finally)");
                 equal(errorList[5], "FOO", "FOO");
                 // cleanup:
-                //Dexie.Promise.on("error").unsubscribe(globalRejectionHandler);
                 window.removeEventListener('unhandledrejection', globalRejectionHandler);
                 start();
             });

--- a/test/tests-exception-handling.js
+++ b/test/tests-exception-handling.js
@@ -446,11 +446,6 @@ asyncTest("Issue #69 Global exception handler for promises", function () {
             // Now just do some Dexie stuff...
             var db = new Dexie("testdb");
             db.version(1).stores({ table1: "id" });
-            /*db.on('error', function(err) {
-                // Global 'db' error handler (will never be called 'cause the error is not in a transaction)
-                console.log("db.on.error: " + err);
-                errorList.push("Got db.on.error: " + err);
-            });*/
             db.open().then(function() {
                 console.log("before");
                 throw "FOO"; // Here a generic error is thrown (not a DB error)

--- a/test/tests-exception-handling.js
+++ b/test/tests-exception-handling.js
@@ -202,8 +202,8 @@ asyncTest("exception in upgrader", function () {
         db.close();
         db = new Dexie("TestUpgrader");
         db.version(1).stores({ cars: "++id,name,brand" });
-        db.version(2).upgrade(function (trans) { trans.cars.add({ name: "My car", brand: "Pegeut" }); });
-        db.version(3).upgrade(function (trans) {
+        db.version(2).upgrade(function () { db.cars.add({ name: "My car", brand: "Pegeut" }); });
+        db.version(3).upgrade(function () {
             throw new Error("Oops. Failing in upgrade function");
         });
         return db.open();

--- a/test/tests-exception-handling.js
+++ b/test/tests-exception-handling.js
@@ -397,6 +397,7 @@ asyncTest("Issue #69 Global exception handler for promises", function () {
         console.log("Got error: " + ev.reason);
         if (errorList.indexOf(ev.reason) === -1) // Current implementation: accept multiple redundant triggers
             errorList.push(ev.reason);
+        ev.preventDefault();
     }
 
     //Dexie.Promise.on("error", globalRejectionHandler);

--- a/test/tests-open.js
+++ b/test/tests-open.js
@@ -256,7 +256,7 @@ asyncTest("Issue #76 Dexie inside Web Worker", function () {
 
             db.open();
             ok(true, "Could open the database");
-
+            
             return db.transaction('rw', db.table1, function() {
                 ok(true, "Could create a transaction");
                 db.table1.add({ name: "My first object" }).then(function(id) {

--- a/test/tests-promise.js
+++ b/test/tests-promise.js
@@ -165,7 +165,6 @@ asyncTest("onunhandledrejection should not propagate if catched after finally", 
     function logErr (ev) {
         ok(false, "Should already be catched:" + ev.reason);
     }
-    //Promise.on('error', logErr);
     window.addEventListener('unhandledrejection', logErr);
     var p = new Promise((resolve, reject)=>{
         reject("apa");
@@ -303,14 +302,13 @@ asyncTest("Issue #97 A transaction may be lost after calling Dexie.Promise.resol
     }
 });*/
 
-asyncTest("Promise.on.error", ()=> {
+asyncTest("unhandledrejection", ()=> {
     var errors = [];
     function onError(ev) {
         errors.push(ev.reason);
-        return false;
+        ev.preventDefault();
     }
     window.addEventListener('unhandledrejection', onError);
-    //Dexie.Promise.on('error', onError);
     
     new Dexie.Promise((resolve, reject) => {
         reject ("error");
@@ -318,18 +316,17 @@ asyncTest("Promise.on.error", ()=> {
     setTimeout(()=>{
         equal(errors.length, 1, "Should be one error there");
         equal(errors[0], "error", "Should be our error there");
-        //Dexie.Promise.on.error.unsubscribe(onError);
         window.removeEventListener('unhandledrejection', onError);
 
         start();
     }, 40);
 });
 
-asyncTest("Promise.on.error2", ()=> {
+asyncTest("unhandledrejection2", ()=> {
     var errors = [];
     function onError(ev) {
         errors.push(ev.reason);
-        return false;
+        ev.preventDefault();
     }
     window.addEventListener('unhandledrejection', onError);
     
@@ -345,17 +342,16 @@ asyncTest("Promise.on.error2", ()=> {
     setTimeout(()=>{
         equal(errors.length, 1, "Should be one error there");
         equal(errors[0], "error", "Should be our error there");
-        //Dexie.Promise.on.error.unsubscribe(onError);
         window.removeEventListener('unhandledrejection', onError);
         start();
     }, 40);
 });
 
-asyncTest("Promise.on.error3", ()=> {
+asyncTest("unhandledrejection3", ()=> {
     var errors = [];
     function onError(ev) {
         errors.push(ev.reason);
-        return false;
+        ev.preventDefault();
     }
     window.addEventListener('unhandledrejection', onError);
     

--- a/test/tests-promise.js
+++ b/test/tests-promise.js
@@ -130,13 +130,14 @@ asyncTest ("Promise.follow chained", ()=>{
     //});
 });
 
-asyncTest("Promise.on.error should propagate once", 1, function(){
+asyncTest("onunhandledrejection should propagate once", 1, function(){
     var Promise = Dexie.Promise;
-    function logErr (e) {
-        ok(true, e);
+    function logErr (ev) {
+        ok(true, ev.reason);
         return false;
     }
-    Promise.on('error', logErr);
+    
+    window.addEventListener('unhandledrejection', logErr);
     var p = new Promise((resolve, reject)=>{
         reject("apa");
     }).finally(()=>{
@@ -153,18 +154,19 @@ asyncTest("Promise.on.error should propagate once", 1, function(){
     });
     Promise.all([p, p2, p3, p4]).finally(()=>{
         setTimeout(()=>{
-            Promise.on('error').unsubscribe(logErr);
+            window.removeEventListener('unhandledrejection', logErr);
             start();
         }, 1);
     });
 });
 
-asyncTest("Promise.on.error should not propagate if catched after finally", 1, function(){
+asyncTest("onunhandledrejection should not propagate if catched after finally", 1, function(){
     var Promise = Dexie.Promise;
-    function logErr (e) {
-        ok(false, "Should already be catched:" + e);
+    function logErr (ev) {
+        ok(false, "Should already be catched:" + ev.reason);
     }
-    Promise.on('error', logErr);
+    //Promise.on('error', logErr);
+    window.addEventListener('unhandledrejection', logErr);
     var p = new Promise((resolve, reject)=>{
         reject("apa");
     }).finally(()=>{
@@ -185,7 +187,7 @@ asyncTest("Promise.on.error should not propagate if catched after finally", 1, f
 
     Promise.all([p, p2, p3, p4]).finally(()=>{
         setTimeout(()=>{
-            Promise.on('error').unsubscribe(logErr);
+            window.removeEventListener('unhandledrejection', logErr);
             start();
         }, 1);
     });
@@ -303,11 +305,12 @@ asyncTest("Issue #97 A transaction may be lost after calling Dexie.Promise.resol
 
 asyncTest("Promise.on.error", ()=> {
     var errors = [];
-    function onError(e, p) {
-        errors.push(e);
+    function onError(ev) {
+        errors.push(ev.reason);
         return false;
     }
-    Dexie.Promise.on('error', onError);
+    window.addEventListener('unhandledrejection', onError);
+    //Dexie.Promise.on('error', onError);
     
     new Dexie.Promise((resolve, reject) => {
         reject ("error");
@@ -315,18 +318,20 @@ asyncTest("Promise.on.error", ()=> {
     setTimeout(()=>{
         equal(errors.length, 1, "Should be one error there");
         equal(errors[0], "error", "Should be our error there");
-        Dexie.Promise.on.error.unsubscribe(onError);
+        //Dexie.Promise.on.error.unsubscribe(onError);
+        window.removeEventListener('unhandledrejection', onError);
+
         start();
     }, 40);
 });
 
 asyncTest("Promise.on.error2", ()=> {
     var errors = [];
-    function onError(e, p) {
-        errors.push(e);
+    function onError(ev) {
+        errors.push(ev.reason);
         return false;
     }
-    Dexie.Promise.on('error', onError);
+    window.addEventListener('unhandledrejection', onError);
     
     new Dexie.Promise((resolve, reject) => {
         new Dexie.Promise((resolve2, reject2) => {
@@ -340,18 +345,19 @@ asyncTest("Promise.on.error2", ()=> {
     setTimeout(()=>{
         equal(errors.length, 1, "Should be one error there");
         equal(errors[0], "error", "Should be our error there");
-        Dexie.Promise.on.error.unsubscribe(onError);
+        //Dexie.Promise.on.error.unsubscribe(onError);
+        window.removeEventListener('unhandledrejection', onError);
         start();
     }, 40);
 });
 
 asyncTest("Promise.on.error3", ()=> {
     var errors = [];
-    function onError(e, p) {
-        errors.push(e);
+    function onError(ev) {
+        errors.push(ev.reason);
         return false;
     }
-    Dexie.Promise.on('error', onError);
+    window.addEventListener('unhandledrejection', onError);
     
     new Dexie.Promise((resolve, reject) => {
         new Dexie.Promise((resolve2, reject2) => {
@@ -364,7 +370,7 @@ asyncTest("Promise.on.error3", ()=> {
     
     setTimeout(()=>{
         equal(errors.length, 0, "Should be zarro errors there");
-        Dexie.Promise.on.error.unsubscribe(onError);
+        window.removeEventListener('unhandledrejection', onError);
         start();
     }, 40);
 });

--- a/test/tests-promise.js
+++ b/test/tests-promise.js
@@ -1,5 +1,6 @@
 ﻿import Dexie from 'dexie';
 import {module, stop, start, asyncTest, equal, ok} from 'QUnit';
+import {spawnedTest} from './dexie-unittest-utils';
 
 module("promise");
 
@@ -366,4 +367,32 @@ asyncTest("Promise.on.error3", ()=> {
         Dexie.Promise.on.error.unsubscribe(onError);
         start();
     }, 40);
+});
+
+spawnedTest("Dexie.Promise should act as being derived from global Promise", function* () {
+
+    ok (Dexie.Promise !== Promise, "Just make sure global Promise isnt set to Dexie.Promise");
+    
+    let p = new Dexie.Promise(resolve => resolve());
+    ok (p instanceof Promise, "new Dexie.Promise() instanceof window.Promise");
+
+    //
+    // Extend a static Promise method on global Promise:
+    //
+    Promise.myStaticMethod = function () {
+        return "hello";
+    }
+    //
+    // Extend a statefull method on global Promise:
+    //
+    Promise.prototype.myMethod = function (callback) {
+        return "hola";
+    }
+        
+    equal (Dexie.Promise.myStaticMethod(), "hello", "Could invoke a statically derived method");
+    equal (p.myMethod(), "hola", "Could invoke a derived method");
+    
+    // Cleanup
+    delete Promise.myStaticMethod;
+    delete Promise.prototype.myMethod;
 });

--- a/test/tests-promise.js
+++ b/test/tests-promise.js
@@ -368,31 +368,3 @@ asyncTest("Promise.on.error3", ()=> {
         start();
     }, 40);
 });
-
-spawnedTest("Dexie.Promise should act as being derived from global Promise", function* () {
-
-    ok (Dexie.Promise !== Promise, "Just make sure global Promise isnt set to Dexie.Promise");
-    
-    let p = new Dexie.Promise(resolve => resolve());
-    ok (p instanceof Promise, "new Dexie.Promise() instanceof window.Promise");
-
-    //
-    // Extend a static Promise method on global Promise:
-    //
-    Promise.myStaticMethod = function () {
-        return "hello";
-    }
-    //
-    // Extend a statefull method on global Promise:
-    //
-    Promise.prototype.myMethod = function (callback) {
-        return "hola";
-    }
-        
-    equal (Dexie.Promise.myStaticMethod(), "hello", "Could invoke a statically derived method");
-    equal (p.myMethod(), "hola", "Could invoke a derived method");
-    
-    // Cleanup
-    delete Promise.myStaticMethod;
-    delete Promise.prototype.myMethod;
-});

--- a/test/tests-tranx.js
+++ b/test/tests-tranx.js
@@ -1,0 +1,51 @@
+import Dexie from 'dexie';
+import {module, stop, start, asyncTest, equal, ok} from 'QUnit';
+import {resetDatabase, spawnedTest} from './dexie-unittest-utils';
+
+"use strict";
+
+var db = new Dexie("TestDBTranx");
+db.version(1).stores({
+    items: "id"
+});
+
+module("tranx", {
+    setup: function () {
+        stop();
+        resetDatabase(db).catch(function (e) {
+            ok(false, "Error resetting database: " + e.stack);
+        }).finally(start);
+    },
+    teardown: function () {
+    }
+});
+
+asyncTest("Should be able to use global Promise within transaction scopes", function(){
+    db.tranx('rw', db.items, trans => {
+        return window.Promise.resolve().then(()=> {
+            ok(Dexie.currentTransaction == trans, "Transaction scopes should persist through Promise.resolve()");
+            return db.items.add({ id: "foobar" });
+        }).then(()=>{
+            return Promise.resolve();
+        }).then(()=>{
+            ok(Dexie.currentTransaction == trans, "Transaction scopes should persist through Promise.resolve()");
+            return db.items.get('foobar');
+        });
+    }).then (function(foobar){
+        equal(foobar.id, 'foobar', "Transaction should have lived throughout the Promise.resolve() chain");
+    }).catch (e => {
+        ok(false, `Error: ${e.stack || e}`);
+    }).finally(start);
+});
+
+
+spawnedTest("Should use Promise.all where applicable", function* (){
+   yield db.tranx('rw', db.items, function* () {
+       let x = yield Promise.resolve(3);
+       yield db.items.bulkAdd([{id: 'a'}, {id: 'b'}]);
+       let all = yield Promise.all(db.items.get('a'), db.items.get('b'));
+       equal (all.length, 2);
+       equal (all[0].id, 'a');
+       equal (all[1].id, 'b');
+   });
+});

--- a/test/tests-tranx.js
+++ b/test/tests-tranx.js
@@ -38,6 +38,118 @@ asyncTest("Should be able to use global Promise within transaction scopes", func
     }).finally(start);
 });
 
+asyncTest("Should be able to use native async await", function() {
+    Promise.resolve().then(()=>{
+        let f = new Function('ok','equal', 'Dexie', 'db', `return db.tranx('rw', db.items, async ()=>{
+            let trans = Dexie.currentTransaction;
+            ok(!!trans, "Should have a current transaction");
+            await db.items.add({id: 'foo'});
+            ok(Dexie.currentTransaction === trans, "Transaction persisted between await calls of Dexie.Promise");
+            await window.Promise.resolve();
+            ok(Dexie.currentTransaction === trans, "Transaction persisted between await calls of global Promise");
+            await (async ()=>{})();
+            ok(Dexie.currentTransaction === trans, "Transaction persisted between await calls of native Promise");
+            await window.Promise.resolve().then(()=>{
+                ok(Dexie.currentTransaction === trans, "Transaction persisted after window.Promise.resolve().then()");
+                return (async ()=>{})(); // Resolve with native promise
+            }).then(()=>{
+                ok(Dexie.currentTransaction === trans, "Transaction persisted after native promise completion");
+                return window.Promise.resolve();
+            }).then(()=>{
+                ok(Dexie.currentTransaction === trans, "Transaction persisted after window.Promise.resolve().then()");
+                return (async ()=>{})();
+            });
+            ok(Dexie.currentTransaction === trans, "Transaction persisted between await calls of mixed promises");
+            
+            try {
+                let foo = await db.items.get('foo');
+                ok(true, "YOUR BROWSER HAS COMPATIBILITY BETWEEN NATIVE PROMISES AND INDEXEDDB!");
+            } catch (e) {
+                ok(true, "Browser has no compatibility between native promises and indexedDB.");
+            }
+        })`);
+        return f(ok, equal, Dexie, db);
+    }).catch(e => {
+        ok(true, `This browser does not support native async functions`);
+    }).then(start);
+});
+
+const NativePromise = (()=>{
+    try {
+        return new Function("return (async ()=>{})().constructor")();
+    } catch(e) {
+        return window.Promise; 
+    }
+})();
+
+asyncTest("Must not leak PSD zone", function() {
+    ok(Dexie.currentTransaction === null, "Should not have an ongoing transaction to start with")
+    let hiddenDiv = document.createElement("div");
+    let mutationObserverPromise = new Promise(resolve=>{
+        (new MutationObserver(() => {
+            ok(Dexie.currentTransaction === null, "Must not leak zones in patched await microtasks");
+            resolve();
+        })).observe(hiddenDiv, { attributes: true });
+    });
+    
+    db.tranx('rw', db.items, ()=>{
+        let trans = Dexie.currentTransaction;
+        ok(trans !== null, "Should have a current transaction");
+        let otherZonePromise;
+        Dexie.ignoreTransaction(()=>{
+            ok(Dexie.currentTransaction == null, "No Transaction in this zone");
+            function promiseFlow () {
+                return NativePromise.resolve().then(()=>{
+                    if(Dexie.currentTransaction !== null) ok(false, "PSD zone leaked");
+                    return NativePromise.resolve();
+                });
+            };
+            otherZonePromise = promiseFlow();
+            for (let i=0;i<100;++i) {
+                otherZonePromise = otherZonePromise.then(promiseFlow);
+            }
+        });
+        // In parallell with the above 2*100 async tasks are being executed and verified,
+        // maintain the transaction zone below:
+        return NativePromise.resolve().then(()=> {
+            ok(Dexie.currentTransaction === trans, "Still same transaction 1");
+            // Make sure native async functions maintains the zone:
+            let f = new Function('ok', 'equal', 'Dexie', 'trans', 'hiddenDiv', 'mutationObserverPromise','NativePromise',
+            `return (async ()=>{
+                ok(Dexie.currentTransaction === trans, "Still same transaction 2");
+                await NativePromise.resolve();
+                ok(Dexie.currentTransaction === trans, "Still same transaction 3");
+                await Dexie.Promise.resolve();
+                ok(Dexie.currentTransaction === trans, "Still same transaction 4");
+                await window.Promise.resolve();
+                ok(Dexie.currentTransaction === trans, "Still same transaction 5");
+                hiddenDiv.setAttribute('i', '1'); // Trigger mutation observer
+                return mutationObserverPromise;
+            })()`);
+            return f(ok, equal, Dexie, trans, hiddenDiv, mutationObserverPromise, NativePromise);
+        }).catch (e => {
+            // Could not test native async functions in this browser.
+            debugger;
+            ok(true, "Native async function not supported in this browser");
+        }).then(()=>{
+            // NativePromise
+            ok(Dexie.currentTransaction === trans, "Still same transaction");
+            return Promise.resolve();
+        }).then(()=>{
+            // window.Promise
+            ok(Dexie.currentTransaction === trans, "Still same transaction");
+            return Dexie.Promise.resolve();
+        }).then(()=>{
+            // Dexie.Promise
+            ok(Dexie.currentTransaction === trans, "Still same transaction");
+            return otherZonePromise; // wait for the foreign zone promise to complete.
+        }).then(()=>{
+            ok(Dexie.currentTransaction === trans, "Still same transaction");
+        });
+    }).catch(e => {
+        ok(false, `Error: ${e.stack || e}`);
+    }).then(start);
+});
 
 spawnedTest("Should use Promise.all where applicable", function* (){
    yield db.tranx('rw', db.items, function* () {

--- a/tools/build-utils.js
+++ b/tools/build-utils.js
@@ -208,7 +208,7 @@ export function babelTransform(source, destination) {
                 "transform-es2015-classes",
                 "transform-es2015-computed-properties",
                 "transform-es2015-constants",
-                "transform-es2015-destructuring",
+                //"transform-es2015-destructuring", // Requires big __restructurer function to occupy space onto the result.
                 //"transform-es2015-for-of",
                 //"transform-es2015-function-name",         // Slightly increases the code size, but could improve debugging experience a bit.
                 "transform-es2015-literals",

--- a/tools/build-utils.js
+++ b/tools/build-utils.js
@@ -207,8 +207,8 @@ export function babelTransform(source, destination) {
                 "transform-es2015-block-scoping",
                 "transform-es2015-classes",
                 "transform-es2015-computed-properties",
-                //"transform-es2015-constants",
-                //"transform-es2015-destructuring",
+                "transform-es2015-constants",
+                "transform-es2015-destructuring",
                 //"transform-es2015-for-of",
                 //"transform-es2015-function-name",         // Slightly increases the code size, but could improve debugging experience a bit.
                 "transform-es2015-literals",


### PR DESCRIPTION
This pull request upgrades the master branch with all changes from the temporary branch next/v2.

News in version 2:

* Support for async / await in Typescript 2.0 and Angular2.
* Support for native async/await in Chrome and Edge
* Deprecation of Dexie.Promise.on('error'). Use the standard `window.addEventListener('unhandledrejection', callback)` instead.
* No need to use Dexie.Promise.all(). Just use Promise.all().

API Differencies:

* WriteableTable and WriteableCollection are gone and instead incorporated into Table and Collection.
* Promise.on('error') is deprecated and should be replaced with windowaddEventListener('unhandledrejection')
