### PR TITLE
Support for standard 'unhandledrejection'

### DIFF
--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -458,7 +458,7 @@ export default function Observable(db) {
             Dexie.vip(function() {
                 readChanges(latestRevision).catch('DatabaseClosedError', e=>{
                     // Handle database closed error gracefully while reading changes.
-                    // Don't bubble to db.on.error or Promise.on.error.
+                    // Don't trigger unhandledrejection
                     // Even though we intercept the close() method, it might be called when in the middle of
                     // reading changes and then that flow will cancel with DatabaseClosedError.
                 });
@@ -539,7 +539,7 @@ export default function Observable(db) {
             readChanges(Observable.latestRevision[db.name]).then(cleanup).then(consumeIntercommMessages)
             .catch('DatabaseClosedError', e=>{
                 // Handle database closed error gracefully while reading changes.
-                // Don't bubble to db.on.error or Promise.on.error.
+                // Don't signal 'unhandledrejection'.
                 // Even though we intercept the close() method, it might be called when in the middle of
                 // reading changes and then that flow will cancel with DatabaseClosedError.
             })

--- a/addons/Dexie.Syncable/test/tests-syncable.js
+++ b/addons/Dexie.Syncable/test/tests-syncable.js
@@ -51,10 +51,10 @@
 			});
 		});
 		window.addEventListener('unhandledrejection', onError);
-		function onError (err) {
+		function onError (ev) {
 			window.removeEventListener('unhandledrejection', onError);
 			db1.close();
-			ok(false, err);
+			ok(false, ev.reason);
 			start();
 		}
 		db1.syncable.on('statusChanged', function (newStatus) {

--- a/addons/Dexie.Syncable/test/tests-syncable.js
+++ b/addons/Dexie.Syncable/test/tests-syncable.js
@@ -50,12 +50,13 @@
 				db1.objects.update(key, {name: "four"});
 			});
 		});
-		db1.on('error', function onError (err) {
-			db1.on('error').unsubscribe(onError);
+		window.addEventListener('unhandledrejection', onError);
+		function onError (err) {
+			window.removeEventListener('unhandledrejection', onError);
 			db1.close();
 			ok(false, err);
 			start();
-		});
+		}
 		db1.syncable.on('statusChanged', function (newStatus) {
 			ok(true, "Status changed to " + Dexie.Syncable.StatusTexts[newStatus]);
 		});

--- a/addons/Dexie.Syncable/test/tests-syncprovider.js
+++ b/addons/Dexie.Syncable/test/tests-syncprovider.js
@@ -72,9 +72,6 @@
         db2.open().then(function () {
             console.log("db2 opened");
         });
-        db2.on.error.subscribe(function (error) {
-            console.error("db2 error: " + error);
-        });
 
         db2.on('changes', function (changes, partial) {
             console.log("db2.on('changes'): changes.length: " + changes.length + "\tpartial: " + (partial ? "true" : "false"));

--- a/samples/typescript/src/app.ts
+++ b/samples/typescript/src/app.ts
@@ -24,12 +24,6 @@ document.addEventListener('DOMContentLoaded', async function () {
     // Test it:
     console.log("Hello world!");
 
-    // It's always a good practice to put this listener in the bootstrapping of your app:
-    Dexie.Promise.on.error.subscribe(e => {
-        // Log any uncatched error. In case you forgot to catch something...
-        console.error(e);
-    });
-    
     try {
         //
         // Let's clear and re-seed the database:

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -27,6 +27,8 @@
     "location": false,
     "chrome": false,
     "document": false,
-    "MutationObserver": false
+    "MutationObserver": false,
+    "CustomEvent": false,
+    "dispatchEvent": false
   }
 }

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -670,6 +670,8 @@ export default function Dexie(dbName, options) {
     // Events
     //
     this.on = Events(this, "error", "populate", "blocked", "versionchange", {ready: [promisableChain, nop]});
+    this.on.error.subscribe = Debug.deprecated("Dexie.on.error", this.on.error.subscribe);
+    this.on.error.unsubscribe = Debug.deprecated("Dexie.on.error.unsubscribe", this.on.error.unsubscribe);
 
     this.on.ready.subscribe = override (this.on.ready.subscribe, function (subscribe) {
         return (subscriber, bSticky) => {

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -678,7 +678,7 @@ export default function Dexie(dbName, options) {
             Dexie.vip(()=>{
                 if (openComplete) {
                     // Database already open. Call subscriber asap.
-                    Promise.resolve().then(subscriber);
+                    if (!dbOpenError) Promise.resolve().then(subscriber);
                     // bSticky: Also subscribe to future open sucesses (after close / reopen) 
                     if (bSticky) subscribe(subscriber); 
                 } else {

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -670,9 +670,7 @@ function globalError(err, promise) {
     } catch (e) {}
     if (rv !== false) try {
         var event, eventData = {promise: promise, reason: err};
-        /*if (_global.PromiseRejectionEvent) { // Don't use. In chromw, makes it fire twice!
-            event = new PromiseRejectionEvent(UNHANDLEDREJECTION, eventData);
-        } else*/ if (_global.document && document.createEvent) {
+        if (_global.document && document.createEvent) {
             event = document.createEvent('Event');
             event.initEvent(UNHANDLEDREJECTION, true, true);
             extend(event, eventData);
@@ -682,6 +680,9 @@ function globalError(err, promise) {
         }
         if (event && _global.dispatchEvent) {
             dispatchEvent(event);
+            if (!_global.PromiseRejectionEvent && _global.onunhandledrejection)
+                // No native support for PromiseRejectionEvent but user has set window.onunhandledrejection. Manually call it.
+                try {_global.onunhandledrejection(event);} catch (_) {}
         }
         if (!event.defaultPrevented) {
             // Backward compatibility: fire to events registered at Promise.on.error

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -1,8 +1,8 @@
 import {doFakeAutoComplete, tryCatch, props,
-        setProp, _global, getPropertyDescriptor, getArrayOf} from './utils';
+        setProp, _global, getPropertyDescriptor, getArrayOf, extend} from './utils';
 import {reverseStoppableEventChain, nop, callBoth, mirror} from './chaining-functions';
 import Events from './Events';
-import {debug, prettyStack, getErrorWithStack} from './debug';
+import {debug, prettyStack, getErrorWithStack, deprecated} from './debug';
 
 //
 // Promise Class for Dexie library
@@ -84,7 +84,7 @@ var asap = function (callback, args) {
 
 var isOutsideMicroTick = true, // True when NOT in a virtual microTick.
     needsNewPhysicalTick = true, // True when a push to microtickQueue must also schedulePhysicalTick()
-    unhandledErrors = [], // Rejected promises that has occured. Used for firing Promise.on.error and promise.onuncatched.
+    unhandledErrors = [], // Rejected promises that has occured. Used for firing unhandledrejection.
     rejectingErrors = [], // Tracks if errors are being re-rejected during onRejected callback.
     currentFulfiller = null,
     rejectionMapper = mirror; // Remove in next major when removing error mapping of DOMErrors and DOMExceptions
@@ -327,8 +327,12 @@ props (Promise, {
         reverseStoppableEventChain,
         defaultErrorHandler] // Default to defaultErrorHandler
     })
-    
+
 });
+
+var PromiseOnError = Promise.on.error;
+PromiseOnError.subscribe = deprecated ("Promise.on('error')", PromiseOnError.subscribe);
+PromiseOnError.unsubscribe = deprecated ("Promise.on('error').unsubscribe", PromiseOnError.unsubscribe);
 
 /**
 * Take a potentially misbehaving resolver function and make sure
@@ -657,15 +661,35 @@ export function usePSD (psd, fn, a1, a2, a3) {
     }
 }
 
+const UNHANDLEDREJECTION = "unhandledrejection";
+
 function globalError(err, promise) {
     var rv;
     try {
         rv = promise.onuncatched(err);
     } catch (e) {}
     if (rv !== false) try {
-        Promise.on.error.fire(err, promise); // TODO: Deprecated and use same global handler as bluebird.
+        var event, eventData = {promise: promise, reason: err};
+        /*if (_global.PromiseRejectionEvent) { // Don't use. In chromw, makes it fire twice!
+            event = new PromiseRejectionEvent(UNHANDLEDREJECTION, eventData);
+        } else*/ if (_global.document && document.createEvent) {
+            event = document.createEvent('Event');
+            event.initEvent(UNHANDLEDREJECTION, true, true);
+            extend(event, eventData);
+        } else if (_global.CustomEvent) {
+            event = new CustomEvent(UNHANDLEDREJECTION, {detail: eventData});
+            extend(event, eventData);
+        }
+        if (event && _global.dispatchEvent) {
+            dispatchEvent(event);
+        }
+        if (!event.defaultPrevented) {
+            // Backward compatibility: fire to events registered at Promise.on.error
+            Promise.on.error.fire(err, promise);
+        }
     } catch (e) {}
 }
+
 
 /* **KEEP** 
 

--- a/test/tests-exception-handling.js
+++ b/test/tests-exception-handling.js
@@ -546,11 +546,6 @@ asyncTest("Issue #69 Global exception handler for promises", function () {
             // Now just do some Dexie stuff...
             var db = new Dexie("testdb");
             db.version(1).stores({ table1: "id" });
-            db.on('error', function(err) {
-                // Global 'db' error handler (will never be called 'cause the error is not in a transaction)
-                console.log("db.on.error: " + err);
-                errorList.push("Got db.on.error: " + err);
-            });
             db.open().then(function() {
                 console.log("before");
                 throw "FOO"; // Here a generic error is thrown (not a DB error)

--- a/test/tests-exception-handling.js
+++ b/test/tests-exception-handling.js
@@ -8,10 +8,6 @@ db.on("populate", function (trans) {
     db.users.add({ id: 1, first: "David", last: "Fahlander", username: "dfahlander", email: ["david@awarica.com", "daw@thridi.com"], pets: ["dog"] });
     db.users.add({ id: 2, first: "Karl", last: "Cedersköld", username: "kceder", email: ["karl@ceder.what"], pets: [] });
 });
-function dbOnErrorHandler (e) {
-    ok(false, "An error bubbled out to the db.on('error'). Should not happen because all tests should catch their errors themselves. " + e);
-}
-db.on("error", dbOnErrorHandler);
 
 module("exception-handling", {
     setup: function () {
@@ -497,8 +493,8 @@ asyncTest("Issue #69 Global exception handler for promises", function () {
     var errorList = [];
     function globalRejectionHandler(ev) {
         console.log("Got error: " + ev.reason);
-        if (errorList.indexOf(e) === -1) // Current implementation: accept multiple redundant triggers
-            errorList.push(e);
+        if (errorList.indexOf(ev.reason) === -1) // Current implementation: accept multiple redundant triggers
+            errorList.push(ev.reason);
         ev.preventDefault();
     }
 

--- a/test/tests-exception-handling.js
+++ b/test/tests-exception-handling.js
@@ -27,11 +27,12 @@ asyncTest("Uncaught promise should signal 'unhandledrejection'", function(){
         ++onErrorSignals;
         ev.preventDefault();
     }
-    window.addEventListener('unhandledrejection', onerror);
+    var prevUnhandledRejection = window.onunhandledrejection;
+    window.onunhandledrejection = onerror;
     db.users.add({ id: 1 });
     setTimeout(()=> {
         equal(onErrorSignals, 1, "'unhandledrejection' should have been signaled");
-        window.removeEventListener('unhandledrejection', onerror);
+        window.onunhandledrejection = prevUnhandledRejection;
         start();
     }, 100);
 });

--- a/test/tests-promise.js
+++ b/test/tests-promise.js
@@ -129,13 +129,13 @@ asyncTest ("Promise.follow chained", ()=>{
     //});
 });
 
-asyncTest("Promise.on.error should propagate once", 1, function(){
+asyncTest("'unhandledrejection' should propagate once", 1, function(){
     var Promise = Dexie.Promise;
-    function logErr (e) {
-        ok(true, e);
-        return false;
+    function logErr (ev) {
+        ok(true, ev.reason);
+        ev.preventDefault();
     }
-    Promise.on('error', logErr);
+    window.addEventListener('unhandledrejection', logErr);
     var p = new Promise((resolve, reject)=>{
         reject("apa");
     }).finally(()=>{
@@ -152,18 +152,18 @@ asyncTest("Promise.on.error should propagate once", 1, function(){
     });
     Promise.all([p, p2, p3, p4]).finally(()=>{
         setTimeout(()=>{
-            Promise.on('error').unsubscribe(logErr);
+            window.removeEventListener('unhandledrejection', logErr);
             start();
         }, 1);
     });
 });
 
-asyncTest("Promise.on.error should not propagate if catched after finally", 1, function(){
+asyncTest("'unhandledrejection' should not propagate if catched after finally", 1, function(){
     var Promise = Dexie.Promise;
-    function logErr (e) {
-        ok(false, "Should already be catched:" + e);
+    function logErr (ev) {
+        ok(false, "Should already be catched:" + ev.reason);
     }
-    Promise.on('error', logErr);
+    window.addEventListener('unhandledrejection', logErr);
     var p = new Promise((resolve, reject)=>{
         reject("apa");
     }).finally(()=>{
@@ -184,7 +184,7 @@ asyncTest("Promise.on.error should not propagate if catched after finally", 1, f
 
     Promise.all([p, p2, p3, p4]).finally(()=>{
         setTimeout(()=>{
-            Promise.on('error').unsubscribe(logErr);
+            window.removeEventListener('unhandledrejection', logErr);
             start();
         }, 1);
     });
@@ -300,13 +300,13 @@ asyncTest("Issue #97 A transaction may be lost after calling Dexie.Promise.resol
     }
 });*/
 
-asyncTest("Promise.on.error", ()=> {
+asyncTest("unhandledrejection", ()=> {
     var errors = [];
-    function onError(e, p) {
-        errors.push(e);
-        return false;
+    function onError(ev) {
+        errors.push(ev.reason);
+        ev.preventDefault();
     }
-    Dexie.Promise.on('error', onError);
+    window.addEventListener('unhandledrejection', onError);
     
     new Dexie.Promise((resolve, reject) => {
         reject ("error");
@@ -314,18 +314,18 @@ asyncTest("Promise.on.error", ()=> {
     setTimeout(()=>{
         equal(errors.length, 1, "Should be one error there");
         equal(errors[0], "error", "Should be our error there");
-        Dexie.Promise.on.error.unsubscribe(onError);
+        window.removeEventListener('unhandledrejection', onError);
         start();
     }, 40);
 });
 
-asyncTest("Promise.on.error2", ()=> {
+asyncTest("unhandledrejection2", ()=> {
     var errors = [];
-    function onError(e, p) {
-        errors.push(e);
-        return false;
+    function onError(ev) {
+        errors.push(ev.reason);
+        ev.preventDefault();
     }
-    Dexie.Promise.on('error', onError);
+    window.addEventListener('unhandledrejection', onError);
     
     new Dexie.Promise((resolve, reject) => {
         new Dexie.Promise((resolve2, reject2) => {
@@ -339,18 +339,18 @@ asyncTest("Promise.on.error2", ()=> {
     setTimeout(()=>{
         equal(errors.length, 1, "Should be one error there");
         equal(errors[0], "error", "Should be our error there");
-        Dexie.Promise.on.error.unsubscribe(onError);
+        window.removeEventListener('unhandledrejection', onError);
         start();
     }, 40);
 });
 
-asyncTest("Promise.on.error3", ()=> {
+asyncTest("unhandledrejection3", ()=> {
     var errors = [];
-    function onError(e, p) {
-        errors.push(e);
-        return false;
+    function onError(ev) {
+        errors.push(ev.reason);
+        ev.preventDefault();
     }
-    Dexie.Promise.on('error', onError);
+    window.addEventListener('unhandledrejection', onError);
     
     new Dexie.Promise((resolve, reject) => {
         new Dexie.Promise((resolve2, reject2) => {
@@ -363,7 +363,7 @@ asyncTest("Promise.on.error3", ()=> {
     
     setTimeout(()=>{
         equal(errors.length, 0, "Should be zarro errors there");
-        Dexie.Promise.on.error.unsubscribe(onError);
+        window.removeEventListener('unhandledrejection', onError);
         start();
     }, 40);
 });


### PR DESCRIPTION
* Support for window.addEventListener('unhandledrejection').
* Deprecation of Promise.on.error and db.on.error.
