### PR TITLE
Resolving #350 - Typescript sample in 2.0.0-beta breaks on Firefox

### DIFF
--- a/samples/typescript/README.md
+++ b/samples/typescript/README.md
@@ -9,7 +9,9 @@ This is a sample on how to use Dexie.js with Typescript and babel. The following
 
 ## Install
 Start a root / admin shell and write:
-sudo npm install  (on windows, run "npm install" as admin in this directory)
+```
+npm install
+```
 
 ## Build
 ```
@@ -18,10 +20,9 @@ npm run build
 
 ## Run
 ```
-npm install -g http-server
-http-server . -a localhost -p 8081
-Surf to http://localhost:8081/src/app.html
+npm test
 ```
+Surf to http://localhost:8081/src/app.html
 
 # The app
 The application stores a simple contact database using a relational database model, where each contact can have
@@ -34,9 +35,3 @@ The tables are mapped to typescript classes and interfaces.
 The sample shows how to subclass Dexie in typescript and define the tables.
 
 It also shows how to map a typescript class to a database table and call methods on database objects.
-
-# The build system
-npm run build will transpile the code in three steps:
-1. tsc      (typescript -&gt; es6)
-2. babel    (es6 -&gt; es5 commonJs)
-3. webpack  (commonJS -&gt; plain monolit minified js)

--- a/samples/typescript/package.json
+++ b/samples/typescript/package.json
@@ -3,10 +3,9 @@
   "version": "1.0.0",
   "description": "Sample on how to use Dexie.js with Typescript",
   "scripts": {
-    "build": "npm run build:ts && npm run build:babel && npm run build:webpack",
+    "build": "npm run build:ts && npm run build:rollup",
     "build:ts": "node node_modules/typescript/bin/tsc",
-    "build:babel": "node_modules/.bin/babel out/ts --out-dir out/babel",
-    "build:webpack": "node node_modules/webpack/bin/webpack -d out/babel/app.js out/bundle.js",
+    "build:rollup": "node node_modules/rollup/bin/rollup out/ts/app.js -f iife -o out/bundle.js",
     "clean": "rm -rf out",
     "test": "http-server . -a localhost -p 8081"
   },
@@ -25,15 +24,10 @@
   },
   "homepage": "https://github.com/dfahlander/Dexie.js#readme",
   "dependencies": {
-    "dexie": "2.0.0-beta.2",
-    "typescript": "^2.1.0-dev.20161012"
+    "dexie": "^2.0.0-beta.2"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.0",
-    "babel-core": "^6.1.4",
-    "babel-plugin-transform-runtime": "^6.6.0",
-    "babel-preset-es2015": "^6.1.4",
-    "typescript": "^1.8.7",
-    "webpack": "^1.12.14"
+    "rollup": "0.20.5",
+    "typescript": "2.1.0-dev.20161012"
   }
 }

--- a/samples/typescript/src/app.html
+++ b/samples/typescript/src/app.html
@@ -3,6 +3,7 @@
 <head>
     <title>Demo how to include Dexie with typescript</title>
     <link rel="stylesheet" href="app.css" />
+    <script src="../node_modules/dexie/dist/dexie.js"></script>
     <script src="../out/bundle.js"></script>
 </head>
 <body>

--- a/samples/typescript/tsconfig.json
+++ b/samples/typescript/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "es6",
-        "target": "es6",
+        "target": "es5",
         "noImplicitAny": true,
         "removeComments": false,
         "sourceMap": true,
@@ -9,6 +9,7 @@
         "moduleResolution": "node"
     },
     "files": [
+        "node_modules/typescript/lib/lib.es6.d.ts",
         "src/console.ts",
         "src/appdb.ts",
         "src/app.ts"

--- a/src/Dexie.d.ts
+++ b/src/Dexie.d.ts
@@ -192,7 +192,7 @@ declare module Dexie {
         tables: { [type: string]: Table<any, any> };
         storeNames: Array<string>;
         on: {
-            (eventName: string, subscriber: () => any): void;
+            (eventName: string, subscriber: (...args:any[]) => any): void;
             (eventName: 'complete', subscriber: () => any): void;
             (eventName: 'abort', subscriber: () => any): void;
             (eventName: 'error', subscriber: (error:any) => any): void;
@@ -207,9 +207,9 @@ declare module Dexie {
     }
 
     interface DexieEvent {
-        subscribe(fn: () => any): void;
-        unsubscribe(fn: () => any): void;
-        fire(): any;
+        subscribe(fn: (...args:any[]) => any): void;
+        unsubscribe(fn: (...args:any[]) => any): void;
+        fire(...args:any[]): any;
     }
 
     interface DexieErrorEvent {
@@ -234,7 +234,11 @@ declare module Dexie {
         name: string;
         schema: TableSchema;
         hook: {
-            (eventName: string, subscriber: () => any): void;
+            (eventName: string, subscriber: (...args:any[]) => any): void;
+            (eventName: 'creating', subscriber: (primKey:Key, obj:T, transaction:Transaction) => any): void;
+            (eventName: 'reading', subscriber: (obj:T) => T | any): void;
+            (eventName: 'updating', subscriber: (modifications:Object, primKey:Key, obj:T, transaction:Transaction) => any): void;
+            (eventName: 'deleting', subscriber: (primKey:Key, obj:T, transaction:Transaction) => any): void;
             creating: DexieEvent;
             reading: DexieEvent;
             updating: DexieEvent;


### PR DESCRIPTION
Running the 'typescript' sample in Dexie 2.0.0-beta.2 was only tested on IE, Edge, Chrome and Opera.
When tested on Firefox, it threw "InvalidStateError".

Reason for this is that babel's Promise shim seems to be incompatible with indexedDB on Firefox.

Now that Typescript 2.1 support direct transpilation towards ES5, there is no need to involve babel in the build process.