### PR TITLE
Support blobs when hooks are involved

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -184,6 +184,13 @@ export function shallowClone(obj) {
     return rv;
 }
 
+//https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+var intrinsicTypes =
+    "Boolean,String,Date,RegExp,Blob,File,FileList,ArrayBuffer,DataView,Uint8ClampedArray,ImageData,Map,Set"
+    .split(',').concat(
+        flatten([8,16,32,64].map(num=>["Int","Uint","Float"].map(t=>t+num+"Array")))
+    ).filter(t=>_global[t]).map(t=>global[t])
+
 export function deepClone(any) {
     if (!any || typeof any !== 'object') return any;
     var rv;
@@ -192,9 +199,8 @@ export function deepClone(any) {
         for (var i = 0, l = any.length; i < l; ++i) {
             rv.push(deepClone(any[i]));
         }
-    } else if (any instanceof Date) {
-        rv = new Date();
-        rv.setTime(any.getTime());
+    } else if (intrinsicTypes.indexOf(any.constructor) >= 0) {
+        rv = any;
     } else {
         rv = any.constructor ? Object.create(any.constructor.prototype) : {};
         for (var prop in any) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -184,12 +184,17 @@ export function shallowClone(obj) {
     return rv;
 }
 
+const concat = [].concat;
+export function flatten (a) {
+    return concat.apply([], a);
+}
+
 //https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 var intrinsicTypes =
     "Boolean,String,Date,RegExp,Blob,File,FileList,ArrayBuffer,DataView,Uint8ClampedArray,ImageData,Map,Set"
     .split(',').concat(
         flatten([8,16,32,64].map(num=>["Int","Uint","Float"].map(t=>t+num+"Array")))
-    ).filter(t=>_global[t]).map(t=>global[t])
+    ).filter(t=>_global[t]).map(t=>_global[t])
 
 export function deepClone(any) {
     if (!any || typeof any !== 'object') return any;
@@ -278,9 +283,4 @@ export function getArrayOf (arrayLike) {
     a = new Array(i);
     while (i--) a[i] = arguments[i];
     return a;
-}
-
-const concat = [].concat;
-export function flatten (a) {
-    return concat.apply([], a);
 }

--- a/test/dexie-unittest-utils.js
+++ b/test/dexie-unittest-utils.js
@@ -132,11 +132,11 @@ export function spawnedTest (name, num, promiseGenerator) {
 export function promisedTest (name, num, asyncFunction) {
     if (!asyncFunction) {
         asyncFunction = num;
-        asyncTest(name, ()=>asyncFunction()
+        asyncTest(name, ()=>Promise.resolve().then(asyncFunction)
             .catch(e => ok(false, e.stack || e))
             .then(start));
     } else {
-        asyncTest(name, num, ()=>asyncFunction()
+        asyncTest(name, num, ()=>Promise.resolve().then(asyncFunction)
             .catch(e => ok(false, e.stack || e))
             .then(start));
     }

--- a/test/tests-all.js
+++ b/test/tests-all.js
@@ -1,14 +1,15 @@
-﻿import "./tests-crud-hooks";
-import "./tests-misc";
-import "./tests-yield";
-import "./tests-whereclause.js";
+﻿import "./tests-table.js";
 import "./tests-collection.js";
-import "./tests-table.js";
-import "./tests-extendability.js";
-import "./tests-promise.js";
+import "./tests-whereclause.js";
 import "./tests-transaction.js";
-import "./tests-asyncawait.js";
 import "./tests-open.js";
+import "./tests-yield";
+import "./tests-asyncawait.js";
 import "./tests-exception-handling.js";
 import "./tests-upgrading.js";
+import "./tests-misc";
+import "./tests-promise.js";
+import "./tests-extendability.js";
+import "./tests-crud-hooks";
+import "./tests-blobs";
 //import "./tests-performance.js"; Not required. Should make other performance tests separately instead.

--- a/test/tests-asyncawait.js
+++ b/test/tests-asyncawait.js
@@ -2,8 +2,6 @@ import Dexie from 'dexie';
 import {module, stop, start, asyncTest, equal, ok} from 'QUnit';
 import {resetDatabase, spawnedTest, promisedTest} from './dexie-unittest-utils';
 
-"use strict";
-
 const hasNativeAsyncFunctions = false;
 try {
     hasNativeAsyncFunctions = !!new Function(`return (async ()=>{})();`)().then;

--- a/test/tests-blobs.js
+++ b/test/tests-blobs.js
@@ -1,0 +1,68 @@
+import Dexie from 'dexie';
+import {module, stop, start, asyncTest, equal, ok} from 'QUnit';
+import {resetDatabase, promisedTest} from './dexie-unittest-utils';
+
+var db = new Dexie("TestDBBinary");
+db.version(1).stores({
+    items: "id"
+});
+
+module("blobs", {
+    setup: function () {
+        stop();
+        resetDatabase(db).catch(function (e) {
+            ok(false, "Error resetting database: " + e.stack);
+        }).finally(start);
+    },
+    teardown: function () {
+    }
+});
+
+function readBlob (blob) {
+    return new Promise ((resolve, reject) => {
+        let reader = new FileReader();
+        reader.onloadend = ev => resolve (ev.target.result);
+        reader.onerror = ev => reject(ev.target.error);
+        reader.onabort = ev => reject(new Error("Blob Aborted"));
+        reader.readAsArrayBuffer(blob);
+    });
+}
+
+function arraysAreEqual (a1, a2) {
+    let length = a1.length;
+    if (a2.length !== length) return false;
+    for (var i=0; i<length; ++i) {
+        if (a1[i] !== a2[i]) return false;
+    }
+    return true;
+}
+
+promisedTest (`Test blobs`, async ()=>{
+    let binaryData = new Uint8Array([1,2,3,4]);
+    let blob = new Blob([binaryData], {type: 'application/octet-binary'});
+    await db.items.add ({id: 1, blob: blob });
+    let back = await db.items.get(1);
+    let arrayBuffer = await readBlob(back.blob);
+    let resultBinaryData = new Uint8Array(arrayBuffer);
+    ok(arraysAreEqual(resultBinaryData, binaryData), "Arrays should be equal");
+});
+
+promisedTest (`Test blob with creating hook applied`, async ()=>{
+    function updatingHook (modifications, primKey, obj, trans) {
+        ok (modifications.blob instanceof Blob, "When hook is called, the modifications should point to a Blob object");
+    }
+    try {
+        db.items.hook('updating', updatingHook);
+        let binaryData = new Uint8Array([1,2,3,4]);
+        let blob = new Blob([binaryData], {type: 'application/octet-binary'});
+        await db.items.add ({id: 1 });
+        await db.items.put ({id: 1, blob: blob });
+        let back = await db.items.get(1);
+        let arrayBuffer = await readBlob(back.blob);
+        let resultBinaryData = new Uint8Array(arrayBuffer);
+        ok(arraysAreEqual(resultBinaryData, binaryData), "Arrays should be equal");
+    } finally {
+        db.items.hook('updating').unsubscribe(updatingHook);
+    }
+});
+


### PR DESCRIPTION
Support for intrinsic objects (Blobs, Typed arrays ect) in deepClone() so that they will be treated as primitive object and not be deeply cloned. Only deep clone custom objects.

Added unit tests for blob support. The first one succeeds (we had blob support already when not using hooks). But the second one failed before the fix.
