### PR TITLE
New tool: Dexie.waitFor() keeps transaction alive.

### DIFF
--- a/src/Promise.js
+++ b/src/Promise.js
@@ -2,6 +2,7 @@ import {doFakeAutoComplete, tryCatch, props, setProp, _global,
     getPropertyDescriptor, getArrayOf, extend} from './utils';
 import {nop, callBoth, mirror} from './chaining-functions';
 import {debug, prettyStack, getErrorWithStack} from './debug';
+import {exceptions} from './errors';
 
 //
 // Promise and Zone (PSD) for Dexie library
@@ -251,6 +252,14 @@ props(Promise.prototype, {
                 stack_being_generated = false;
             }
         }
+    },
+
+    timeout: function (ms, msg) {
+        return ms < Infinity ?
+            new Promise((resolve, reject) => {
+                var handle = setTimeout(() => reject(new exceptions.Timeout(msg)), ms);
+                this.then(resolve, reject).finally(clearTimeout.bind(null, handle));
+            }) : this;
     }
 });
 
@@ -299,7 +308,7 @@ props (Promise, {
             values.map(value => Promise.resolve(value).then(resolve, reject));
         });
     },
-    
+
     PSD: {
         get: ()=>PSD,
         set: value => PSD = value


### PR DESCRIPTION
Inspired by @wwoods solution described  in #374 and the new [indexeddb-promises proposal](https://github.com/inexorabletash/indexeddb-promises/issues/11), I've added the method Dexie.waitFor() that may wait on a non-indexedDB Promise or Promise-returning function to complete and keep transaction alive during the whole lifetime of that task.

Implementation was also inspired by the elegant code in [polyfill.js](https://github.com/inexorabletash/indexeddb-promises/blob/master/polyfill.js) by @inexorabletash.