### PR TITLE
Stop using localStorage for recording database names

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -29,6 +29,7 @@
     "document": false,
     "MutationObserver": false,
     "CustomEvent": false,
-    "dispatchEvent": false
+    "dispatchEvent": false,
+    "localStorage": false
   }
 }

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -66,8 +66,10 @@ var DEXIE_VERSION = '{version}',
     isIEOrEdge = typeof navigator !== 'undefined' && /(MSIE|Trident|Edge)/.test(navigator.userAgent),
     hasIEDeleteObjectStoreBug = isIEOrEdge,
     hangsOnDeleteLargeKeyRange = isIEOrEdge,
-    dexieStackFrameFilter = frame => !/(dexie\.js|dexie\.min\.js)/.test(frame);
+    dexieStackFrameFilter = frame => !/(dexie\.js|dexie\.min\.js)/.test(frame),
+    dbNamesDB;// Global database for backing Dexie.getDatabaseNames() on browser without indexedDB.webkitGetDatabaseNames() 
 
+// Init debug
 Debug.setDebug(Debug.debug, dexieStackFrameFilter);
 
 export default function Dexie(dbName, options) {
@@ -542,13 +544,10 @@ export default function Dexie(dbName, options) {
                     db.on("versionchange").fire(ev);
                 });
                 
-                if (!hasNativeGetDatabaseNames) {
-                    // Update localStorage with list of database names
-                    globalDatabaseList(function (databaseNames) {
-                        if (databaseNames.indexOf(dbName) === -1) return databaseNames.push(dbName);
-                    });
+                if (!hasNativeGetDatabaseNames && dbName !== '__dbnames') {
+                    dbNamesDB.dbnames.put({name: dbName}).catch(nop);
                 }
-                
+
                 resolve();
 
             }, reject);
@@ -612,10 +611,7 @@ export default function Dexie(dbName, options) {
                 var req = indexedDB.deleteDatabase(dbName);
                 req.onsuccess = wrap(function () {
                     if (!hasNativeGetDatabaseNames) {
-                        globalDatabaseList(function(databaseNames) {
-                            var pos = databaseNames.indexOf(dbName);
-                            if (pos >= 0) return databaseNames.splice(pos, 1);
-                        });
+                        dbNamesDB.dbnames.delete(dbName).catch(nop);
                     }
                     resolve();
                 });
@@ -2872,20 +2868,6 @@ function preventDefault(event) {
         event.preventDefault();
 }
 
-function globalDatabaseList(cb) {
-    var val,
-        localStorage = Dexie.dependencies.localStorage;
-    if (!localStorage) return cb([]); // Envs without localStorage support
-    try {
-        val = JSON.parse(localStorage.getItem('Dexie.DatabaseNames') || "[]");
-    } catch (e) {
-        val = [];
-    }
-    if (cb(val)) {
-        localStorage.setItem('Dexie.DatabaseNames', JSON.stringify(val));
-    }
-}
-
 function awaitIterator (iterator) {
     var callNext = result => iterator.next(result),
         doThrow = error => iterator.throw(error),
@@ -2993,21 +2975,14 @@ props(Dexie, {
     // Static method for retrieving a list of all existing databases at current host.
     //
     getDatabaseNames: function (cb) {
-        return new Promise(function (resolve, reject) {
-            var getDatabaseNames = getNativeGetDatabaseNamesFn(indexedDB);
-            if (getDatabaseNames) { // In case getDatabaseNames() becomes standard, let's prepare to support it:
-                var req = getDatabaseNames();
-                req.onsuccess = function (event) {
-                    resolve(slice(event.target.result, 0)); // Converst DOMStringList to Array<String>
-                };
-                req.onerror = eventRejectHandler(reject);
-            } else {
-                globalDatabaseList(function (val) {
-                    resolve(val);
-                    return false;
-                });
-            }
-        }).then(cb);
+        var getDatabaseNames = getNativeGetDatabaseNamesFn(Dexie.dependencies.indexedDB);
+        return getDatabaseNames ? new Promise((resolve, reject) => {
+            var req = getDatabaseNames();
+            req.onsuccess = function (event) {
+                resolve(slice(event.target.result, 0)); // Converst DOMStringList to Array<String>
+            };
+            req.onerror = eventRejectHandler(reject);
+        }) : dbNamesDB.dbnames.toCollection().primaryKeys(cb);
     },
     
     defineClass: function (structure) {
@@ -3181,13 +3156,6 @@ props(Dexie, {
     default: Dexie
 });
 
-tryCatch(()=>{
-    // Optional dependencies
-    // localStorage
-    Dexie.dependencies.localStorage =
-        ((typeof chrome !== "undefined" && chrome !== null ? chrome.storage : void 0) != null ? null : _global.localStorage);
-});
-
 // Map DOMErrors and DOMExceptions to corresponding Dexie errors. May change in Dexie v2.0.
 Promise.rejectionMapper = mapError;
 
@@ -3196,3 +3164,18 @@ doFakeAutoComplete(function() {
     Dexie.fakeAutoComplete = fakeAutoComplete = doFakeAutoComplete;
     Dexie.fake = fake = true;
 });
+
+// Initialize dbNamesDB (won't ever be opened on chromium browsers')
+dbNamesDB = new Dexie('__dbnames'); 
+dbNamesDB.version(1).stores({dbnames: 'name'});
+
+(()=>{
+    // Migrate from Dexie 1.x database names stored in localStorage:
+    var DBNAMES = 'Dexie.DatabaseNames';
+    if (typeof localStorage !== undefined && _global.document !== undefined) try {
+        // Have localStorage and is not executing in a worker. Lets migrate from Dexie 1.x.
+        JSON.parse(localStorage.getItem(DBNAMES) || "[]")
+            .forEach(name => dbNamesDB.put({name: name}).catch(nop));
+        localStorage.removeItem(DBNAMES);
+    } catch (_e) {}
+})();

--- a/test/tests-open.js
+++ b/test/tests-open.js
@@ -189,7 +189,7 @@ asyncTest("open database without specifying version or schema", Dexie.Observable
     });
 });
 
-asyncTest("Dexie.getDatabaseNames", 11, function () {
+asyncTest("Dexie.getDatabaseNames", 13, function () {
     var defaultDatabases = [];
     var db1, db2;
     Dexie.getDatabaseNames(function (names) {
@@ -226,6 +226,13 @@ asyncTest("Dexie.getDatabaseNames", 11, function () {
     }).then(function (names) {
         equal(names.length, defaultDatabases.length, "All of our databases have been deleted");
         ok(!names.indexOf("TestDB2") !== -1, "TestDB2 not in database list anymore");
+    }).then(function (names) {
+        return Dexie.exists("nonexistingDB");
+    }).then(function (exists) {
+        ok(!exists, "'nonexistingDB' should not exist indeed");
+        return Dexie.getDatabaseNames();
+    }).then(function (names) {
+        ok(!names.indexOf("nonexistingDB") !== -1, "nonexistingDB must not have been recorded when calling Dexie.exists()");
     }).catch(function (err) {
         ok(false, err.stack || err);
     }).finally(function () {


### PR DESCRIPTION
Dexie.getDatabaseNames() polyfills indexedDB.getDatabaseNames() for on non-chromium browsers. To do this, it adds the name of every opened table into a localStorage property. Silly not to use an indexedDB database? Reason may have been because I was allergic to storing meta-data in indexedDB. But it's actually even more ridiculous to store it in localStorage so I've moved it to use indexedDB (database '__dbnames') for recording database names so that the feature works in workers as well.

The code size went actually smaller with this change, so I think it's in the right path.

This change will automatically migrate existing localStorage data into the new __dbnames table.
