### PR TITLE
Fixes in Dexie.Syncable README

### DIFF
--- a/addons/Dexie.Syncable/README.md
+++ b/addons/Dexie.Syncable/README.md
@@ -29,7 +29,7 @@ import 'dexie-syncable'; // will import dexie-observable as well.
      * [Dexie.js](https://github.com/dfahlander/Dexie.js/wiki/Dexie.js)
        * [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API)
    * _An implementation of [ISyncProtocol](https://github.com/dfahlander/Dexie.js/wiki/Dexie.Syncable.ISyncProtocol)_
- 
+
 ### Tutorial
 
 #### 1. Include Required Sources
@@ -45,7 +45,7 @@ In your HTML, make sure to include Dexie.js, Dexie.Observable.js, Dexie.Syncable
     </body></html>
 
 #### 2. Use UUID based Primary Keys ($$)
-Two way replication requires not to use auto-incremented keys if any sync node should be able to create objects no matter offline or online. Dexie.Syncable comes with a new syntax when defining your store schemas: the double-dollar prefix ($$). Similary to the ++ prefix in Dexie (meaining auto-incremented primary key), the double-dollar prefix means that the key will be given a universally unique identifier (UUID), in string format (For example "9cc6768c-358b-4d21-ac4d-58cc0fddd2d6").
+Two way replication cannot use auto-incremented keys if any sync node should be able to create objects no matter if it is offline or online. Dexie.Syncable comes with a new syntax when defining your store schemas: the double-dollar prefix ($$). Similary to the ++ prefix in Dexie (meaning auto-incremented primary key), the double-dollar prefix means that the key will be given a universally unique identifier (UUID), in string format (For example "9cc6768c-358b-4d21-ac4d-58cc0fddd2d6").
 
     var db = new Dexie("MySyncedDB");
     db.version(1).stores({
@@ -54,7 +54,7 @@ Two way replication requires not to use auto-incremented keys if any sync node s
     });
 
 #### 3. Connect to Server
-You must specify the URL of the server you want to keep in-sync with. This has to be done once in the entire database life-time, but doing it on every startup is ok as well, since it wont affect already connected URLs.
+You must specify the URL of the server you want to keep in-sync with. This has to be done once in the entire database life-time, but doing it on every startup is ok as well, since it won't affect already connected URLs.
 
     // This example uses the WebSocketSyncProtocol included in earlier steps.
     db.syncable.connect ("websocket", "https://syncserver.com/sync");
@@ -63,16 +63,16 @@ You must specify the URL of the server you want to keep in-sync with. This has t
     });
 
 #### 4. Use Your Database
-Query and modify your database as if it was a simple Dexie instance. Any changes will be replicated to server and and change on server or other window will replicate back to you.
+Query and modify your database as if it was a simple Dexie instance. Any changes will be replicated to the server and changes on the server or an other window will replicate back to you.
 
     db.transaction('rw', db.friends, function (friends) {
         friends.add({name: "Arne", shoeSize: 47});
-        friends.where(shoeSize).above(40).each(function (friend) {
+        friends.where('shoeSize').above(40).each(function (friend) {
             console.log("Friend with shoeSize over 40: " + friend.name);
         });
     });
 
-_NOTE: Transactions only provide the Atomicity part of the [ACID](http://en.wikipedia.org/wiki/ACID) properties when using 2-way syncronization. This is due to that the syncronization phase may result in that another change could override the changes. However, it's still meaningfull to use the transaction() since method for atomicity. Atomicity is guaranteed not only locally but also when synced to the server, meaning that a part of the changes will never commit on the server until all changes from the transaction has been synced. In practice, you cannot increment a counter in the database (for example) and expect it to be consistent, but you can be guaranteed that if you add a sequence of objects, all or none of them will replicate._
+_NOTE: Transactions only provide the Atomicity part of the [ACID](http://en.wikipedia.org/wiki/ACID) properties when using 2-way synchronization. This is due to the fact that the syncronization phase may result in another change overwriting the changes. However, it's still meaningful to use the transaction() method for atomicity. Atomicity is guaranteed not only locally but also when synced to the server, meaning that a part of the changes will never commit on the server until all changes from the transaction have been synced. In practice, you cannot increment a counter in the database (for example) and expect it to be consistent, but you can have a guaranteed that if you add a sequence of objects, all or none of them will replicate._
 
 ### API Reference
 
@@ -90,13 +90,13 @@ Text lookup for status numbers
 #### Non-Static Methods and Events
 
 [db.syncable.connect (protocol, url, options)](https://github.com/dfahlander/Dexie.js/wiki/db.syncable.connect())
-Create a presistend a two-way sync connection with given URL.
+Create a persistend two-way sync connection with the given URL.
 
 [db.syncable.disconnect (url)](https://github.com/dfahlander/Dexie.js/wiki/db.syncable.disconnect())
-Stop syncing with given URL but keep revision states until next connect.
+Stop syncing with the given URL but keep revision states until next connect.
 
 [db.syncable.delete(url)](https://github.com/dfahlander/Dexie.js/wiki/db.syncable.delete())
-Delete all states and change queue for given URL 
+Delete all states and change queue for given URL.
 
 [db.syncable.list()](https://github.com/dfahlander/Dexie.js/wiki/db.syncable.list())
 List the URLs of each remote node we have a state saved for.
@@ -105,10 +105,10 @@ List the URLs of each remote node we have a state saved for.
 Event triggered when sync status changes.
 
 [db.syncable.setFilter ([criteria], filter)](https://github.com/dfahlander/Dexie.js/wiki/db.syncable.setFilter())
-Ignore certain objects from being synced defined by given filter.
+Ignore certain objects from being synced defined by the given filter.
 
 [db.syncable.getStatus (url)](https://github.com/dfahlander/Dexie.js/wiki/db.syncable.getStatus())
-Get sync status for given URL.
+Get sync status for the given URL.
 
 
 ### Source
@@ -117,7 +117,7 @@ Get sync status for given URL.
 
 ### Description
 
-Dexie.Syncable enables syncronization with a remote database (of almost any kind). It has it's own API [ISyncProtocol](Dexie.Syncable.ISyncProtocol).
+Dexie.Syncable enables synchronization with a remote database (of almost any kind). It has its own API [ISyncProtocol](Dexie.Syncable.ISyncProtocol).
 The [ISyncProtocol](https://github.com/dfahlander/Dexie.js/wiki/Dexie.Syncable.ISyncProtocol) is pretty straight-forward to implement.
 The implementation of that API defines how client- and server- changes are transported between local and remote nodes. The API support both poll-patterns
 (such as ajax calls) and direct reaction pattern (such as WebSocket or long-polling methods). See samples below for each pattern.


### PR DESCRIPTION
Fix typos.
Change wording of some sentences to make those more readable.
Fix where() call in the example to pass a string ('shoeSize') instead of
a variable.