### PR TITLE
Fix combineUpdateAndUpdate function

### DIFF
--- a/addons/Dexie.Syncable/src/Dexie.Syncable.js
+++ b/addons/Dexie.Syncable/src/Dexie.Syncable.js
@@ -1005,7 +1005,7 @@ export default function Syncable (db) {
             // If prev-change was changing a parent path of this keyPath, we must update the parent path rather than adding this keyPath
             var hadParentPath = false;
             Object.keys(prevChange.mods).filter(function (parentPath) { return keyPath.indexOf(parentPath + '.') === 0; }).forEach(function (parentPath) {
-                setByKeyPath(clonedChange[parentPath], keyPath.substr(parentPath.length + 1), nextChange.mods[keyPath]);
+                setByKeyPath(clonedChange.mods[parentPath], keyPath.substr(parentPath.length + 1), nextChange.mods[keyPath]);
                 hadParentPath = true;
             });
             if (!hadParentPath) {
@@ -1015,7 +1015,7 @@ export default function Syncable (db) {
             // In case prevChange contained sub-paths to the new keyPath, we must make sure that those sub-paths are removed since
             // we must mimic what would happen if applying the two changes after each other:
             Object.keys(prevChange.mods).filter(function (subPath) { return subPath.indexOf(keyPath + '.') === 0; }).forEach(function (subPath) {
-                delete clonedChange[subPath];
+                delete clonedChange.mods[subPath];
             });
         });
         return clonedChange;


### PR DESCRIPTION
Update .mods of previousChange instead the clone of the previousChange object itself.

When the nextChange wanted to update a nested property which was already
set by the previousChange, then we tried to combine with the
previousChange directly instead of its mods.

When the nextChange wanted to update an object in which the
previousChange updated a nested property, we tried to delete the
previous property on the previousChange directly and not its mods.

See also: https://github.com/dfahlander/Dexie.js/issues/397#issuecomment-268009668

Unfortunately I didn't even manage to run the unit tests for Dexie.Syncable as `npm install` tried to install a Dexie version which was not available.