### PR TITLE
Fixes 2016 12 21

### DIFF
--- a/addons/Dexie.Observable/src/Dexie.Observable.d.ts
+++ b/addons/Dexie.Observable/src/Dexie.Observable.d.ts
@@ -31,6 +31,8 @@ declare module 'dexie' {
         // (makes it valid to do new db.observable.SyncNode())
         observable: {SyncNode: Dexie.Observable.SyncNodeConstructor}
 
+        readonly _localSyncNode: Dexie.Observable.SyncNode;
+
         _changes: Dexie.Table<Dexie.Observable.IDatabaseChange & {rev: number}, number>;
         _syncNodes: Dexie.Table<Dexie.Observable.SyncNode, number>;
         _intercomm: Dexie.Table<any, number>;

--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -119,7 +119,7 @@ export default function Observable(db) {
         return function(stores, dbSchema) {
             // Create the _changes and _syncNodes tables
             stores["_changes"] = "++rev";
-            stores["_syncNodes"] = "++id,myRevision,lastHeartBeat,url,isMaster,type,status";
+            stores["_syncNodes"] = "++id,myRevision,lastHeartBeat,&url,isMaster,type,status";
             stores["_intercomm"] = "++id,destinationNode";
             stores["_uncommittedChanges"] = "++id,node"; // For remote syncing when server returns a partial result.
             // Call default implementation. Will populate the dbSchema structures.

--- a/addons/Dexie.Syncable/src/Dexie.Syncable.js
+++ b/addons/Dexie.Syncable/src/Dexie.Syncable.js
@@ -62,9 +62,14 @@ export default function Syncable (db) {
         if (weBecameMaster) {
             // We took over the master role in Observable's cleanup method.
             // We should connect to remote servers now.
+            // At this point, also reconnect servers with status ERROR_WILL_RETRY as well as plain ERROR.
+            // Reason to reconnect to those with plain "ERROR" is that the ERROR state may occur when a database
+            // connection has been closed. The new master would then be expected to reconnect.
+            // Also, this is not an infinite poll(). This is rare event that a new browser tab takes over from
+            // an old closed one. 
             Dexie.ignoreTransaction(()=>Dexie.vip(()=>{
                 return db._syncNodes.where({type: 'remote'})
-                    .filter(node => node.status !== Statuses.OFFLINE && node.status !== Statuses.ERROR)
+                    .filter(node => node.status !== Statuses.OFFLINE)
                     .toArray(connectedRemoteNodes => Promise.all(connectedRemoteNodes.map(node => 
                         db.syncable.connect(node.syncProtocol, node.url, node.syncOptions).catch(e => {
                             console.warn(`Dexie.Syncable: Could not connect to ${node.url}. ${e.stack || e}`);
@@ -96,9 +101,7 @@ export default function Syncable (db) {
             // Don't halt db.ready while connecting (i.e. we do not return a promise here!)
             db._syncNodes
                 .where('type').equals('remote')
-                .and(node =>
-                    node.status !== Statuses.OFFLINE &&
-                    node.status !== Statuses.ERROR)
+                .and(node => node.status !== Statuses.OFFLINE)
                 .toArray(connectedRemoteNodes => {
                     // There are connected remote nodes that we must manage (or take over to manage)
                     connectedRemoteNodes.forEach(
@@ -177,13 +180,28 @@ export default function Syncable (db) {
                         return db.sendMessage('connect', { protocolName: protocolName, url: url, options: options }, masterNode.id, { wantReply: true });
                     });
                 }
+            } else if (db.hasBeenClosed()) {
+                // Database has been closed.
+                return Promise.reject(new Dexie.DatabaseClosedError());
+            } else if (db.hasFailed()) {
+                // Database has failed to open
+                return Promise.reject(new Dexie.InvalidStateError(
+                    "Dexie.Syncable: Cannot connect. Database has failed to open"));
             } else {
-                // Database not yet open
+                // Database not yet open. It may be on its way to open, or open() hasn't yet been called.
                 // Wait for it to open, then connect.
                 var promise = new Promise(function(resolve, reject) {
                     db.on("ready", () => {
-                        let connectPromise = db.syncable.connect(protocolName, url, options);
-                        return db._syncNodes.get({url: url}, node => {
+                        // First, check if this is the very first time we connect to given URL.
+                        // Need to know, because if it is, we should stall the promise returned to
+                        // db.on('ready') to not be fulfilled until the initial sync has succeeded.
+                        return db._syncNodes.get({url}, node => {
+                            // Ok, now we know whether we should await the connect promise or not.
+                            // No matter, we should now connect (will maybe create the SyncNode instance
+                            // representing the given URL)
+                            let connectPromise = db.syncable.connect(protocolName, url, options);
+                            connectPromise.then(resolve, reject);// Resolve the returned promise when connected.
+                            // Ok, so let's see if we should suspend DB queries until connected or not:
                             if (node && node.appliedRemoteRevision) {
                                 // The very first initial sync has been done so we need not wait
                                 // for the connect promise to complete. It can continue in background.
@@ -191,7 +209,7 @@ export default function Syncable (db) {
                                 // the application has put to the database.
                                 return;
                             }
-                            // If this is the very first time we connect to the remote server,
+                            // This was the very first time we connect to the remote server,
                             // we must make sure that the initial sync request succeeeds before resuming
                             // database queries that the application code puts onto the database.
                             // If OFFLINE or other error, don't allow the application to proceed.
@@ -199,16 +217,23 @@ export default function Syncable (db) {
                             // function correctly.
                             return connectPromise;
                         });
-                        // Resolve the returned promise.
-                        connectPromise.then(resolve, reject);
                     });
                     // Force open() to happen. Otherwise connect() may stall forever.
-                    db.open().catch(reject); // If open fails, db.on('ready') may not have been called.
+                    db.open().catch(ex =>{
+                        // If open fails, db.on('ready') may not have been called and we must
+                        // reject promise with InvalidStateError
+                        reject (new Dexie.InvalidStateError(
+                            `Dexie.Syncable: Couldn't connect. Database failed to open`,
+                            ex
+                        ));
+                    }); 
                 });
                 return promise;
             }
         } else {
-            throw new Error("ISyncProtocol '" + protocolName + "' is not registered in Dexie.Syncable.registerSyncProtocol()");
+            return Promise.reject(
+                new Error("ISyncProtocol '" + protocolName + "' is not registered in Dexie.Syncable.registerSyncProtocol()")
+            );
         }
     };
 

--- a/addons/Dexie.Syncable/test/test-syncable-dexie-tests.html
+++ b/addons/Dexie.Syncable/test/test-syncable-dexie-tests.html
@@ -81,6 +81,7 @@
                             console.log("Calling db.sync() on " + db.name);
                             db.syncable.connect("logger", "logger").then(function() {
                                 console.log("connect() promise was resolved (database=" + db.name + ")");
+                            }).catch('DatabaseClosedError', function(){
                             }).catch(function(err) {
                                 console.error("Error from connect() (database=" + db.name + "): " + err.stack || err);
                             });

--- a/src/Dexie.d.ts
+++ b/src/Dexie.d.ts
@@ -101,7 +101,11 @@ export declare class Dexie {
 
     isOpen(): boolean;
 
+    hasBeenClosed(): boolean;
+
     hasFailed(): boolean;
+
+    dynamicallyOpened(): boolean;
 
     backendDB(): IDBDatabase;
 

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -640,6 +640,9 @@ export default function Dexie(dbName, options) {
     this.isOpen = function () {
         return idbdb !== null;
     };
+    this.hasBeenClosed = function () {
+        return dbOpenError && (dbOpenError instanceof exceptions.DatabaseClosed);
+    }
     this.hasFailed = function () {
         return dbOpenError !== null;
     };
@@ -653,10 +656,12 @@ export default function Dexie(dbName, options) {
     this.name = dbName;
 
     // db.tables - an array of all Table instances.
-    setProp(this, "tables", {
-        get: function () {
-            /// <returns type="Array" elementType="Table" />
-            return keys(allTables).map(function (name) { return allTables[name]; });
+    props(this, {
+        tables: {
+            get () {
+                /// <returns type="Array" elementType="Table" />
+                return keys(allTables).map(function (name) { return allTables[name]; });
+            }
         }
     });
 

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -425,7 +425,8 @@ export default function Dexie(dbName, options) {
             }
             return dbReadyPromise.then(()=>tempTransaction(mode, storeNames, fn));
         } else {
-            var trans = db._createTransaction(mode, storeNames, globalSchema).create();
+            var trans = db._createTransaction(mode, storeNames, globalSchema);
+            try { trans.create(); } catch (ex) { return rejection(ex); }
             return trans._promise(mode, function (resolve, reject) {
                 return newScope(function () { // OPTIMIZATION POSSIBLE? newScope() not needed because it's already done in _promise.
                     PSD.trans = trans;

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -3010,7 +3010,7 @@ props(Dexie, {
                 resolve(slice(event.target.result, 0)); // Converst DOMStringList to Array<String>
             };
             req.onerror = eventRejectHandler(reject);
-        }) : dbNamesDB.dbnames.toCollection().primaryKeys(cb);
+        }).then(cb) : dbNamesDB.dbnames.toCollection().primaryKeys(cb);
     },
     
     defineClass: function (structure) {

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -3209,7 +3209,7 @@ dbNamesDB.version(1).stores({dbnames: 'name'});
     if (typeof localStorage !== undefined && _global.document !== undefined) try {
         // Have localStorage and is not executing in a worker. Lets migrate from Dexie 1.x.
         JSON.parse(localStorage.getItem(DBNAMES) || "[]")
-            .forEach(name => dbNamesDB.put({name: name}).catch(nop));
+            .forEach(name => dbNamesDB.dbnames.put({name: name}).catch(nop));
         localStorage.removeItem(DBNAMES);
     } catch (_e) {}
 })();

--- a/test/dexie-unittest-utils.js
+++ b/test/dexie-unittest-utils.js
@@ -2,18 +2,18 @@
 import {ok, start, test, config} from 'QUnit';
 
 // Custom QUnit config options.
-config.urlConfig.push({
-    id: "polyfillIE",
+config.urlConfig.push(/*{
+    id: "polyfillIE", // Remarked because has no effect anymore. Find out why.
 	label: "Include IE Polyfill",
     tooltip: "Enabling this will include the idb-iegap polyfill that makes" +
     " IE10&IE11 support multiEntry and compound indexes as well as compound" +
     " primary keys"
 }, {
-    id: "indexedDBShim",
+    id: "indexedDBShim", // Remarked because has no effect anymore. Need to find out why. Should invoke the shim if set!
     label: "IndexedDBShim (UseWebSQL as backend)",
     tooltip: "Enable this in Safari browsers without indexedDB support or" +
     " with poor indexedDB support"
-}, {
+},*/ {
     id: "dontoptimize",
     label: "Dont optimize tests",
     tooltip: "Always delete and recreate the DB between each test"
@@ -25,10 +25,10 @@ config.urlConfig.push({
     " dexie.js are also included)"
  });
 
-Dexie.debug = window.location.search.indexOf('longstacks=true') !== -1 ? 'dexie' : false;
+Dexie.debug = window.location.search.indexOf('longstacks') !== -1 ? 'dexie' : false;
 if (window.location.search.indexOf('longstacks=tests') !== -1) Dexie.debug = true; // Don't include stuff from dexie.js.
 
-var no_optimize = window.no_optimize || window.location.search.indexOf('dontoptimize=true') !== -1;
+var no_optimize = window.no_optimize || window.location.search.indexOf('dontoptimize') !== -1;
 
 export function resetDatabase(db) {
     /// <param name="db" type="Dexie"></param>

--- a/test/tests-exception-handling.js
+++ b/test/tests-exception-handling.js
@@ -392,8 +392,6 @@ asyncTest("Issue #67 - Regression test - Transaction still fails if error in key
 });
 
 asyncTest("Issue #69 Global exception handler for promises", function () {
-    //
-    Dexie.debug = true;
     var errorList = [];
     function globalRejectionHandler(ev) {
         console.log("Got error: " + ev.reason);
@@ -462,8 +460,9 @@ asyncTest("Issue #69 Global exception handler for promises", function () {
                 equal(errorList[3].message, "Converting a rejected standard promise to Dexie.Promise but don't catch it", "Converting a rejected standard promise to Dexie.Promise but don't catch it");
                 equal(errorList[4], "forth error (uncatched but with finally)", "forth error (uncatched but with finally)");
                 equal(errorList[5].message, "FOO", "FOO");
-                errorList.slice(6).forEach((e,i) => {
-                    console.error (i + ": " + e.stack);
+                errorList.slice(6).map((e, i)=>`Unexpected error: ${(i+6) + ": " + e.stack}`).forEach(txt => {
+                    console.error(txt);
+                    ok(false, txt);
                 });
                 // cleanup:
                 window.removeEventListener('unhandledrejection', globalRejectionHandler);


### PR DESCRIPTION
* Bug in rewritten Dexie.getDatabaseNames()
* Added missing properties to typings (d.ts) files of Dexie.d.ts and Dexie.Observable.d.ts.
* Dexie.Syncable: Correction of initial sync handling: 
  * Don't await db.syncable.connect() to fulfill or reject each time the local database is opened. If DB has ever been synced with remote, we should rely on the offline state until connection is restablished. No need to halt queries while connecting.
  * Very first time a database connects to a server, we MUST be online and wait for the connect to complete. Assume that the initial sync is essential for the application to function.
* Correction after running various unit tests for the addons:
  * Make sure to never reopen a closed database by accident.
* Dexie.Syncable: Made 'url' index unique as it should be. Existing db's may be needing to increment their version.
* Unit Test framework: Respect custom qUnit checkboxes.
* Dexie bug: When outside a transaction, exception could be thrown instead of returning a rejected promise. This happened if either A) Database had been closed, B) indexedDB API was missing or C) Database had failed to open. Corrected so that a rejected promise is returned instead.
* Dexie: Added `db.hasBeenClosed()`
