### PR TITLE
Make partials threshold configurable

### DIFF
--- a/addons/Dexie.Syncable/api.d.ts
+++ b/addons/Dexie.Syncable/api.d.ts
@@ -58,6 +58,7 @@ export enum DatabaseChangeType {
  * 
  */
 export interface ISyncProtocol {
+    partialsThreshold?: number;
     sync (
         context: IPersistedContext,
         url: string,

--- a/addons/Dexie.Syncable/src/Dexie.Syncable.js
+++ b/addons/Dexie.Syncable/src/Dexie.Syncable.js
@@ -236,6 +236,17 @@ Syncable.registerSyncProtocol = function(name, protocolInstance) {
     /// </summary>
     /// <param name="name" type="String">Provider name</param>
     /// <param name="protocolInstance" type="ISyncProtocol">Implementation of ISyncProtocol</param>
+    const partialsThreshold = protocolInstance.partialsThreshold;
+    if (typeof partialsThreshold === 'number') {
+        // Don't allow NaN or negative threshold
+        if (isNaN(partialsThreshold) || partialsThreshold < 0) {
+            throw new Error('The given number for the threshold is not supported');
+        }
+        // If the threshold is 0 we will not send any client changes but will get server changes
+    } else {
+        // Use Infinity as the default so simple protocols don't have to care about partial synchronization
+        protocolInstance.partialsThreshold = Infinity;
+    }
     Syncable.registeredProtocols[name] = protocolInstance;
 };
 

--- a/addons/Dexie.Syncable/src/connect-protocol.js
+++ b/addons/Dexie.Syncable/src/connect-protocol.js
@@ -20,7 +20,7 @@ export default function initConnectProtocol(db, protocolInstance, dbAliveID, opt
 
   return function connectProtocol(node, activePeer) {
     /// <param name="node" type="db.observable.SyncNode"></param>
-    const getLocalChangesForNode = initGetLocalChangesForNode(db, hasMoreToGive);
+    const getLocalChangesForNode = initGetLocalChangesForNode(db, hasMoreToGive, protocolInstance.partialsThreshold);
 
     const url = activePeer.url;
 

--- a/addons/Dexie.Syncable/src/get-local-changes-for-node/get-local-changes-for-node.js
+++ b/addons/Dexie.Syncable/src/get-local-changes-for-node/get-local-changes-for-node.js
@@ -4,8 +4,8 @@ import getBaseRevisionAndMaxClientRevision from './get-base-revision-and-max-cli
 import initGetChangesSinceRevision from './get-changes-since-revision';
 import initGetTableObjectsAsChanges from './get-table-objects-as-changes';
 
-export default function initGetLocalChangesForNode(db, hasMoreToGive) {
-  var MAX_CHANGES_PER_CHUNK = 1000;
+export default function initGetLocalChangesForNode(db, hasMoreToGive, partialsThreshold) {
+  var MAX_CHANGES_PER_CHUNK = partialsThreshold;
 
   return function getLocalChangesForNode(node, cb) {
     /// <summary>

--- a/addons/Dexie.Syncable/test/unit/get-local-changes-for-node/tests-get-changes-since-revision.js
+++ b/addons/Dexie.Syncable/test/unit/get-local-changes-for-node/tests-get-changes-since-revision.js
@@ -225,11 +225,67 @@ asyncTest('should set hasMoreToGive to true if we have more changes than maxChan
   const revision = 1;
   const maxChanges = 2;
   const maxRevision = 4;
+  hasMoreToGive.hasMoreToGive = false;
   function cb(changes, partial, revisionObject) {
     strictEqual(revisionObject.myRevision, createChange3.rev, 'myRevision');
     strictEqual(partial, true, 'is a partial change');
     strictEqual(changes.length, 2, 'get only 2 changes');
-    deepEqual(hasMoreToGive, {hasMoreToGive: true}, 'hasMoreToGive remains false');
+    deepEqual(hasMoreToGive, {hasMoreToGive: true}, 'hasMoreToGive is true');
+  }
+  const changesToAdd = [createChange1, createChange2, createChange3, createChange4];
+  db._changes.bulkAdd(changesToAdd)
+      .then(() => {
+        return getChangesSinceRevision(revision, maxChanges, maxRevision, cb)
+      })
+      .catch(function(err) {
+        ok(false, "Error: " + err);
+      })
+      .finally(start);
+});
+
+
+asyncTest('should set hasMoreToGive to true but give no changes if maxChanges is 0', () => {
+  const createChange1 = {
+    rev: 1,
+    key: 1,
+    type: CREATE,
+    source: 2,
+    table: 'foo',
+    obj: {foo: 'bar'}
+  };
+  const createChange2 = {
+    rev: 2,
+    key: 2,
+    type: CREATE,
+    source: 2,
+    table: 'foo',
+    obj: {foo: 'bar'}
+  };
+  const createChange3 = {
+    rev: 3,
+    key: 3,
+    type: CREATE,
+    source: 2,
+    table: 'foo',
+    obj: {foo: 'bar'}
+  };
+  const createChange4 = {
+    rev: 4,
+    key: 4,
+    type: CREATE,
+    source: 2,
+    table: 'foo',
+    obj: {foo: 'bar'}
+  };
+  const revision = 1;
+  const maxChanges = 0;
+  const maxRevision = 4;
+  hasMoreToGive.hasMoreToGive = false;
+  function cb(changes, partial, revisionObject) {
+    strictEqual(revisionObject.myRevision, revision, 'revision should not change');
+    strictEqual(partial, true, 'is a partial change');
+    strictEqual(changes.length, 0, 'get no changes');
+    deepEqual(hasMoreToGive, {hasMoreToGive: true}, 'hasMoreToGive is true');
   }
   const changesToAdd = [createChange1, createChange2, createChange3, createChange4];
   db._changes.bulkAdd(changesToAdd)

--- a/addons/Dexie.Syncable/test/unit/tests-register-sync-protocol.js
+++ b/addons/Dexie.Syncable/test/unit/tests-register-sync-protocol.js
@@ -1,0 +1,51 @@
+import Dexie from 'dexie';
+import '../../src/Dexie.Syncable';
+import {module, test, strictEqual, raises} from 'QUnit';
+
+module('registerSyncProtocol', {
+  setup: () => {
+  },
+  teardown: () => {
+  }
+});
+
+test('should set partialsThreshold to Infinity if no threshold was given', () => {
+  const protocolName = 'foo';
+  Dexie.Syncable.registerSyncProtocol(protocolName, {
+    sync() {},
+  });
+
+  strictEqual(Dexie.Syncable.registeredProtocols[protocolName].partialsThreshold, Infinity);
+});
+
+test('should save the given partialsThreshold', () => {
+  const protocolName = 'foo';
+  Dexie.Syncable.registerSyncProtocol(protocolName, {
+    sync() {},
+    partialsThreshold: 1000
+  });
+
+  strictEqual(Dexie.Syncable.registeredProtocols[protocolName].partialsThreshold, 1000);
+});
+
+test('should throw an error if the partialsThreshold is NaN or smaller 0', () => {
+  const protocolName = 'foo';
+
+  function fn1() {
+    Dexie.Syncable.registerSyncProtocol(protocolName, {
+      sync() {},
+      partialsThreshold: NaN
+    });
+  }
+
+  raises(fn1, Error, 'NaN test');
+
+  function fn2() {
+    Dexie.Syncable.registerSyncProtocol(protocolName, {
+      sync() {},
+      partialsThreshold: -10
+    });
+  }
+
+  raises(fn2, Error, 'Negative number test');
+});

--- a/addons/Dexie.Syncable/test/unit/unit-tests-all.js
+++ b/addons/Dexie.Syncable/test/unit/unit-tests-all.js
@@ -9,4 +9,5 @@ import './tests-finally-commit-all-changes.js';
 import './tests-get-or-create-sync-node.js';
 import './tests-merge-change.js';
 import './tests-PersistedContext.js';
+import './tests-register-sync-protocol.js';
 import './tests-save-to-uncommitted-changes.js';


### PR DESCRIPTION
Until now Dexie.Syncable sent partial changes when we had more than 1000
changes. With the partialsThreshold property this can be configured
during protocol registration.

Only positive numbers are allowed and if no threshold is given, Infinity
is used. We use Infinity so that simple server implementations of the
protocol don't have to care about partial changes.
If partialsThreshold is 0, Dexie.Syncable will send no changes but will
always set partial to true. This can be used to only get server changes
and ignore any client changes.

Closes https://github.com/dfahlander/Dexie.js/issues/410