### PR TITLE
Fixes for the ajax sync protocol

### DIFF
--- a/samples/remote-sync/ajax/AjaxSyncProtocol.js
+++ b/samples/remote-sync/ajax/AjaxSyncProtocol.js
@@ -23,9 +23,9 @@ Dexie.Syncable.registerSyncProtocol("sample_protocol", {
         //      changes: changes,
         //      syncedRevision: syncedRevision
         //  }
-        //  To make the sample simplified, we assume the server has the exact same specification of how changes are structured.
+        //  To keep the sample simple, we assume the server has the exact same specification of how changes are structured.
         //  In real world, you would have to pre-process the changes array to fit the server specification.
-        //  However, this example shows how to deal with the WebSocket to fullfill the API.
+        //  However, this example shows how to deal with ajax to fulfil the API.
         var request = {
             clientIdentity: context.clientIdentity || null,
             baseRevision: baseRevision,
@@ -37,6 +37,7 @@ Dexie.Syncable.registerSyncProtocol("sample_protocol", {
         // Send the request:
         $.ajax(url, {
             type: 'post',
+            contentType: 'application/json', // Make sure we set the correct content-type header as some servers expect this
             dataType: 'json',
             data: JSON.stringify(request),
             error: function (xhr, textStatus) {
@@ -44,26 +45,41 @@ Dexie.Syncable.registerSyncProtocol("sample_protocol", {
                 onError(textStatus, POLL_INTERVAL);
             },
             success: function (data) {
-                // In this example, the server response is of the following format:
+                // In this example, the server response has the following format:
                 //{
                 //    success: true / false,
                 //    errorMessage: "",
                 //    changes: changes,
                 //    currentRevision: revisionOfLastChange,
-                //    needsResync: false, // Flag telling that server doesnt have given syncedRevision or of other reason wants client to resync.
+                //    needsResync: false, // Flag telling that server doesn't have given syncedRevision or of other reason wants client to resync. ATTENTION: this flag is currently ignored by Dexie.Syncable
+                //    partial: true / false, // The server sent only a part of the changes it has for us. On next resync it will send more based on the clientIdentity
                 //    [clientIdentity: unique value representing the client identity. Only provided if we did not supply a valid clientIdentity in the request.]
                 //}
                 if (!data.success) {
-                    onError (data.errorMessage, Infinity); // Infinity = Dont try again. We would continue getting this error.
+                    onError (data.errorMessage, Infinity); // Infinity = Don't try again. We would continue getting this error.
                 } else {
-                    // Since we got success, we also know that server accepted our changes:
-                    onChangesAccepted();
-                    // Convert the response format to the Dexie.Syncable.Remote.SyncProtocolAPI specification:
-                    applyRemoteChanges (data.changes, data.currentRevision, false, data.needsResync);
-                    onSuccess({ again: POLL_INTERVAL });
                     if ('clientIdentity' in data) {
                         context.clientIdentity = data.clientIdentity;
-                        context.save();
+                        // Make sure we save the clientIdentity sent by the server before we try to resync.
+                        // If saving fails we wouldn't be able to do a partial synchronization
+                        context.save()
+                            .then(() => {
+                            // Since we got success, we also know that server accepted our changes:
+                            onChangesAccepted();
+                            // Convert the response format to the Dexie.Syncable.Remote.SyncProtocolAPI specification:
+                            applyRemoteChanges (data.changes, data.currentRevision, data.partial, data.needsResync);
+                            onSuccess({ again: POLL_INTERVAL });
+                            })
+                            .catch((e) => {
+                                // We didn't manage to save the clientIdentity stop synchronization
+                                onError(e, Infinity);
+                            });
+                    } else {
+                        // Since we got success, we also know that server accepted our changes:
+                        onChangesAccepted();
+                        // Convert the response format to the Dexie.Syncable.Remote.SyncProtocolAPI specification:
+                        applyRemoteChanges (data.changes, data.currentRevision, data.partial, data.needsResync);
+                        onSuccess({ again: POLL_INTERVAL });
                     }
                 }
             }


### PR DESCRIPTION
Fix some typos.

Add contentType property with application/json to the ajax call. Some
servers use it to know when to parse JSON.

Add warning that the needsResync flag is not implemented by
Dexie.Syncable.

Add partials flag to the server reply and pass it to
applyRemoteChanges().

When the server sends us a clientIdentity make sure we save it before
trying to resync. If saving failed we should stop syncing.