### PR TITLE
Fix setImmediate call without qualifier

### DIFF
--- a/src/Promise.js
+++ b/src/Promise.js
@@ -52,7 +52,7 @@ var LONG_STACKS_CLIP_LIMIT = 100,
 */
 var schedulePhysicalTick = (_global.setImmediate ? 
     // setImmediate supported. Those modern platforms also supports Function.bind().
-    setImmediate.bind(null, physicalTick) :
+    _global.setImmediate.bind(null, physicalTick) :
     _global.MutationObserver ?
         // MutationObserver supported
         () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,7 +81,7 @@ export function assert (b) {
 }
 
 export function asap(fn) {
-    if (_global.setImmediate) setImmediate(fn); else setTimeout(fn, 0);
+    if (_global.setImmediate) _global.setImmediate(fn); else setTimeout(fn, 0);
 }
 
 export function getUniqueArray(a) {


### PR DESCRIPTION
This fix the error "setImmediate is undefined" / "cannot call method 'bind' of undefined".

See https://github.com/dfahlander/Dexie.js/issues/485