### PR TITLE
Typings (d.ts) correction of Dexie.exists() and Dexie.delete()

### DIFF
--- a/src/Dexie.d.ts
+++ b/src/Dexie.d.ts
@@ -60,6 +60,10 @@ export declare class Dexie {
     
     static maxKey: Array<Array<void>> | string;
     static minKey: number;
+
+    static exists(dbName: string) : Dexie.Promise<boolean>;
+
+    static delete(dbName: string): Dexie.Promise<void>;
     
     static dependencies: {
         indexedDB: IDBFactory,
@@ -96,8 +100,6 @@ export declare class Dexie {
     close(): void;
 
     delete(): Dexie.Promise<void>;
-
-    exists(name : string) : Dexie.Promise<boolean>;
 
     isOpen(): boolean;
 


### PR DESCRIPTION
Dexie.exists() was non-static. Should be static. Dexie.delete() did only have the non-static db.delete() version. Not the static Dexie.delete(dbName).