### PR TITLE
bubble up `QuotaExceededError` instead of `AbortError: Transaction aborted`

### DIFF
--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -1509,7 +1509,7 @@ export default function Dexie(dbName, options) {
             });
             idbtrans.onabort = wrap(ev => {
                 preventDefault(ev);
-                this.active && this._reject(new exceptions.Abort());
+                this.active && this._reject(new exceptions.Abort(idbtrans.error));
                 this.active = false;
                 this.on("abort").fire(ev);
             });


### PR DESCRIPTION
Fixes #323 

Rather than throwing `Unhandled rejection: AbortError: Transaction aborted` when the user is out of disk space, the underlying transaction error (`QuotaExceededError`) is bubbled up. This allows consumers of the Dexie API to identify `QuotaExceededError`s and handle them accordingly. 

NOTE: I used http://www.cylog.org/utilities/filldisk.jsp to fill up my hard disk to try this code locally.