### PR TITLE
Firefox 53 supports async but still inconmpat w IDB!

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     ],
     "test": [
       "# Build the test suite. Typescript transpiles all but not generators...",
-      "tsc --allowJs -t es5 -m es2015 --outDir tools/tmp/es5/test/ --sourceMap test/tests-all.js [--watch 'Compilation complete.']",
+      "tsc --allowJs -t es5 -m es2015 --outDir tools/tmp/es5/test/ --rootDir . --sourceMap test/tests-all.js [--watch 'Compilation complete.']",
       "rollup -c tools/build-configs/rollup.tests.config.js",
       "# As a last step, let babel transpile the generators....",
       "babel tools/tmp/es5/test/bundle.js -o test/bundle.js --plugins transform-regenerator --source-maps"

--- a/test/is-idb-and-promise-compatible.js
+++ b/test/is-idb-and-promise-compatible.js
@@ -1,0 +1,34 @@
+import Dexie from 'dexie';
+import {NativePromise} from '../src/Promise';
+
+var _resolve = NativePromise.resolve.bind(NativePromise);
+var _then = NativePromise.prototype.then;
+
+export class IdbPromiseIncompatibleError extends Error {
+    constructor() {
+        super("IndexedDB and Promise are incompatible on this browser");
+        this.name = "IdbPromiseIncompatibleError";
+    }
+}
+
+export async function isIdbAndPromiseCompatible() {
+    let db = new Dexie("idbPromiseCompatTest");
+    db.version(1).stores({foo:'bar'});
+    return await db.transaction('r', db.foo, async ()=>{
+        let x = await db.foo.count();
+        let p = _resolve(0);
+        for (let i=0;i<10;++i) {
+            p = _then.call(p, x => x + 1);
+        }
+        let result = await p;
+        console.log("Result: "+ result + " (should be 10");
+        try {
+            await db.foo.count();
+            db.close();
+            return true;
+        } catch (ex) {
+            db.close();
+            throw new IdbPromiseIncompatibleError();
+        }
+    });
+}

--- a/test/tests-asyncawait.js
+++ b/test/tests-asyncawait.js
@@ -1,6 +1,9 @@
 import Dexie from 'dexie';
 import {module, test, equal, ok} from 'QUnit';
 import {resetDatabase, spawnedTest, promisedTest} from './dexie-unittest-utils';
+import {isIdbAndPromiseCompatible} from './is-idb-and-promise-compatible';
+
+const idbAndPromiseCompatible = isIdbAndPromiseCompatible();
 
 const hasNativeAsyncFunctions = false;
 try {
@@ -44,7 +47,7 @@ test("Should be able to use global Promise within transaction scopes", function(
 
 test("Should be able to use native async await", function(assert) {
     let done = assert.async();
-    Promise.resolve().then(()=>{
+    Dexie.Promise.resolve(idbAndPromiseCompatible).then(()=>{
         let f = new Function('ok','equal', 'Dexie', 'db', `return db.transaction('rw', db.items, async ()=>{
             let trans = Dexie.currentTransaction;
             ok(!!trans, "Should have a current transaction");
@@ -98,6 +101,8 @@ test("Should be able to use native async await", function(assert) {
             }
         })`);
         return f(ok, equal, Dexie, db);
+    }).catch('IdbPromiseIncompatibleError', e => {
+        ok (true, `Promise and IndexedDB is incompatible on this browser. Native async await fails in idb transaction by reality`)
     }).catch(e => {
         if (hasNativeAsyncFunctions)
             ok(false, `Error: ${e.stack || e}`);
@@ -114,8 +119,16 @@ const NativePromise = (()=>{
     }
 })();
 
-test("Must not leak PSD zone", function(assert) {
+test("Must not leak PSD zone", async function(assert) {
     let done = assert.async();
+    let compatiblity = await idbAndPromiseCompatible.catch(e=>{
+        return false;
+    });
+    if (!compatiblity) {
+        ok (true, `Promise and IndexedDB is incompatible on this browser. Native async await fails "by design"`);
+        done();
+        return;
+    }
     if (!hasNativeAsyncFunctions) {
         ok(true, "Browser doesnt support native async-await");
         done();
@@ -180,10 +193,11 @@ test("Must not leak PSD zone", function(assert) {
     F(ok, equal, Dexie, db).catch(e => ok(false, e.stack || e)).then(done);
 });
 
-test("Must not leak PSD zone2", function(assert) {
+test("Must not leak PSD zone2", async function(assert) {
     let done = assert.async();
     ok(Dexie.currentTransaction === null, "Should not have an ongoing transaction to start with");
     
+
     db.transaction('rw', db.items, ()=>{
         let trans = Dexie.currentTransaction;
         ok(trans !== null, "Should have a current transaction");
@@ -203,7 +217,7 @@ test("Must not leak PSD zone2", function(assert) {
         });
         // In parallell with the above 2*100 async tasks are being executed and verified,
         // maintain the transaction zone below:        
-        return Promise.resolve().then(()=> {
+        return idbAndPromiseCompatible.then(()=> {
             ok(Dexie.currentTransaction === trans, "Still same transaction 1");
             // Make sure native async functions maintains the zone:
             let f = new Function('ok', 'equal', 'Dexie', 'trans','NativePromise', 'db',
@@ -220,7 +234,9 @@ test("Must not leak PSD zone2", function(assert) {
             return f(ok, equal, Dexie, trans, NativePromise, db);
         }).catch (e => {
             // Could not test native async functions in this browser.
-            if (hasNativeAsyncFunctions)
+            if (e.name === 'IdbPromiseIncompatibleError') {
+                ok (true, `Promise and IndexedDB is incompatible on this browser. Native async await fails "by design" for indexedDB transactions`);
+            } else if (hasNativeAsyncFunctions)
                 ok(false, `Error: ${e.stack || e}`);
             else 
                 ok(true, `This browser does not support native async functions`);
@@ -244,13 +260,19 @@ test("Must not leak PSD zone2", function(assert) {
     }).then(done);
 });
 
-test("Should be able to await Promise.all()", (assert) => {
+test("Should be able to await Promise.all()", async (assert) => {
     let done = assert.async();
     if (!hasNativeAsyncFunctions) {
         ok(true, "Browser doesnt support native async-await");
         done();
         return;
     }    
+    let compatible = await idbAndPromiseCompatible.catch(()=>false);
+    if (!compatible) {
+        ok (true, `Promise and IndexedDB is incompatible on this browser. Native async await fails "by design" for indexedDB transactions`);
+        done();
+        return;
+    }
     (new Function('ok', 'equal', 'Dexie', 'db',
     `return db.transaction('r', db.items, async (trans)=>{
         ok(Dexie.currentTransaction === trans, "Correct initial transaction.");
@@ -321,6 +343,12 @@ spawnedTest("Even when keeping a reference to global Promise, still maintain PSD
 
 spawnedTest ("Sub Transactions with async await", function*() {
     try {
+        let compatible = yield idbAndPromiseCompatible.catch(()=>false);
+        if (!compatible) {
+            ok (true, `Promise and IndexedDB is incompatible on this browser. Native async await fails "by design" for indexedDB transactions`);
+            return;
+        }
+
         yield new Function ('equal', 'ok', 'Dexie', 'db', `return (async ()=>{
             await db.items.bulkAdd([{id: 1}, {id:2}, {id: 3}]);
             let result = await db.transaction('rw', db.items, async ()=>{
@@ -413,7 +441,14 @@ promisedTest ("Should be able to use some simpe native async await even without 
     if (!hasNativeAsyncFunctions) {
         ok(true, "Browser doesnt support native async-await");
         return;
-    }    
+    }
+    
+    let compatible = await idbAndPromiseCompatible.catch(()=>false);
+    if (!compatible) {
+        ok (true, `Promise and IndexedDB is incompatible on this browser. Native async await fails "by design" for indexedDB transactions`);
+        return;
+    }
+
     await (new Function('ok', 'equal', 'Dexie', 'db',
     `return db.transaction('r', db.items, trans=> (async (trans) => {
         ok(Dexie.currentTransaction === trans, "Correct initial transaction.");
@@ -429,7 +464,13 @@ promisedTest ("Should behave outside transactions as well", async () => {
     if (!hasNativeAsyncFunctions) {
         ok(true, "Browser doesnt support native async-await");
         return;
-    }    
+    }
+    let compatible = await idbAndPromiseCompatible.catch(()=>false);
+    if (!compatible) {
+        ok (true, `Promise and IndexedDB is incompatible on this browser. Native async await fails "by design" for indexedDB transactions`);
+        return;
+    }
+    
     await (new Function('ok', 'equal', 'Dexie', 'db', 'GlobalPromise',
     `async function doSomething() {
         ok(!Dexie.currentTransaction, "Should be at global scope.");

--- a/tools/build-configs/rollup.tests.config.js
+++ b/tools/build-configs/rollup.tests.config.js
@@ -7,7 +7,7 @@ const ERRORS_TO_IGNORE = [
 ];
 
 export default {
-  entry: 'tools/tmp/es5/test/tests-all.js',
+  entry: 'tools/tmp/es5/test/test/tests-all.js',
   dest: 'tools/tmp/es5/test/bundle.js',
   format: 'umd',
   sourceMap: true,


### PR DESCRIPTION
Unit tests fails for Firefox 53. The unit tests that fails are those that test native async-await support. 

As described in #317, browser vendors (now only Firefox and Safari) still have incompatibility between their native Promise and their native IDBTransaction implementations. Dexie works around this by using its own Promise implementation, but when it comes to native async/await, we are totally in the hands of the native promise compatiblity. Chrome, Opera and Microsoft Edge have solved their previous incompatibility issues and they support both native async/await and Promise/IDB compatibility. Firefox used to lack both, but now they created the async/await support without solving the Idb/Promise incompatibility.

In summary, unit tests now do a feature test whether there is compatibility between IndexedDB transactions and Promise or not. If not compatible, we won't run those unit tests since they would fail badly with TransactionInactiveError.
