### PR TITLE
Fix typing for .on('ready')

### DIFF
--- a/src/Dexie.d.ts
+++ b/src/Dexie.d.ts
@@ -273,7 +273,7 @@ export declare module Dexie {
     }
 
     interface DbEvents extends DexieEventSet {
-        (eventName: 'ready', subscriber: () => any, bSticky: boolean): void;
+        (eventName: 'ready', subscriber: () => any, bSticky?: boolean): void;
         (eventName: 'populate', subscriber: () => any): void;
         (eventName: 'blocked', subscriber: () => any): void;
         (eventName: 'versionchange', subscriber: (event: IDBVersionChangeEvent) => any): void;


### PR DESCRIPTION
According to the docs [here](http://dexie.org/docs/Dexie/Dexie.on.ready), `bSticky` is optional. It was causing TypeScript compiler errors when omitted, however.