### PR TITLE
fix typescript (type error) on adding addons

### DIFF
--- a/addons/Dexie.Observable/src/Dexie.Observable.d.ts
+++ b/addons/Dexie.Observable/src/Dexie.Observable.d.ts
@@ -113,4 +113,6 @@ declare module 'dexie' {
     }
 }
 
-export default Dexie.Observable;
+declare var dexieObservable: (db: Dexie) => void;
+
+export default dexieObservable;

--- a/addons/Dexie.Syncable/src/Dexie.Syncable.d.ts
+++ b/addons/Dexie.Syncable/src/Dexie.Syncable.d.ts
@@ -98,5 +98,6 @@ declare module 'dexie' {
     }
 }
 
-export default Dexie.Syncable;
+declare var dexieSyncable: (db: Dexie) => void;
 
+export default dexieSyncable;


### PR DESCRIPTION
solves problem in [#567](https://github.com/dfahlander/Dexie.js/issues/567)

Typescript expected typeof `(db: Dexie) => void`

```
import Dexie from 'dexie';
import dexieObservable from 'dexie-observable';
import relationships from 'dexie-relationships';
...

export class DataBase extends Dexie {

    constructor() {
      super("YourDB", { addons: [relationships, dexieObservable] });
...
```