### PR TITLE
Change apply-changes in Dexie.Syncable to use a transaction to manage changes instead of chained promises

### DIFF
--- a/addons/Dexie.Syncable/src/apply-changes.js
+++ b/addons/Dexie.Syncable/src/apply-changes.js
@@ -4,31 +4,35 @@ import bulkUpdate from './bulk-update';
 
 export default function initApplyChanges(db) {
   return function applyChanges(changes, offset) {
-    const length = changes.length;
-    // This is the base case for the recursion
-    if (offset >= length) return Dexie.Promise.resolve(null);
-    const firstChange = changes[offset];
-    let i, change;
-    for (i=offset + 1; i < length; ++i) {
-      change = changes[i];
-      if (change.type !== firstChange.type ||
-          change.table !== firstChange.table)
-        break;
-    }
-    const table = db.table(firstChange.table);
-    const specifyKeys = !table.schema.primKey.keyPath;
-    const changesToApply = changes.slice(offset, i);
-    const changeType = firstChange.type;
-    const bulkPromise =
-        changeType === CREATE ?
-            table.bulkPut(changesToApply.map(c => c.obj), specifyKeys ?
-                changesToApply.map(c => c.key) : undefined) :
-            changeType === UPDATE ?
-                bulkUpdate(table, changesToApply) :
-                changeType === DELETE ?
-                    table.bulkDelete(changesToApply.map(c => c.key)) :
-                    Dexie.Promise.resolve(null);
+    if (offset === changes.length)
+      return Dexie.Promise.resolve(null);
+    changes = changes.slice(offset);
 
-    return bulkPromise.then(()=>applyChanges(changes, i));
+    let collectedChanges = {};
+    changes.map((change) => {
+      if (!collectedChanges.hasOwnProperty(change.table)) {
+        collectedChanges[change.table] = [[], [], [], []];
+      }
+      collectedChanges[change.table][change.type].push(change);
+    });
+    let table_names = Object.keys(collectedChanges);
+    let tables = table_names.map((table) => db.table(table));
+
+    return db.transaction("rw", tables, () => {
+      table_names.map((table_name) => {
+        const table = db.table(table_name);
+        const specifyKeys = !table.schema.primKey.keyPath;
+        const createChangesToApply = collectedChanges[table_name][CREATE];
+        const deleteChangesToApply = collectedChanges[table_name][DELETE];
+        const updateChangesToApply = collectedChanges[table_name][UPDATE];
+        if (createChangesToApply.length > 0)
+          table.bulkPut(createChangesToApply.map(c => c.obj), specifyKeys ?
+            createChangesToApply.map(c => c.key) : undefined);
+        if (updateChangesToApply.length > 0)
+          bulkUpdate(table, updateChangesToApply);
+        if (deleteChangesToApply.length > 0)
+          table.bulkDelete(deleteChangesToApply.map(c => c.key));
+      });
+    });
   };
 }

--- a/addons/Dexie.Syncable/src/finally-commit-all-changes.js
+++ b/addons/Dexie.Syncable/src/finally-commit-all-changes.js
@@ -22,12 +22,12 @@ export default function initFinallyCommitAllChanges(db, node) {
         // 2. Apply uncommitted changes and delete each uncommitted change
         return db._uncommittedChanges.where('node').equals(node.id).toArray();
       }).then(function (uncommittedChanges) {
-        return applyChanges(uncommittedChanges, 0);
+        return applyChanges(uncommittedChanges);
       }).then(function () {
         return db._uncommittedChanges.where('node').equals(node.id).delete();
       }).then(function () {
         // 3. Apply last chunk of changes
-        return applyChanges(changes, 0);
+        return applyChanges(changes);
       }).then(function () {
         // Get what revision we are at now:
         return db._changes.orderBy('rev').last();

--- a/addons/Dexie.Syncable/test/unit/tests-apply-changes.js
+++ b/addons/Dexie.Syncable/test/unit/tests-apply-changes.js
@@ -22,17 +22,6 @@ module('applyChanges', {
   }
 });
 
-asyncTest('should resolve with "null" if the offset is equal to the number of changes', () => {
-  // Base case for the recursion
-  applyChanges([], 0)
-    .then((val) => {
-      strictEqual(val, null);
-    })
-    .catch(function(err) {
-      ok(false, "Error: " + err);
-    })
-    .finally(start);
-});
 
 asyncTest('should be able to handle changes belonging to different tables', () => {
   const fooCreateChange = {
@@ -59,6 +48,21 @@ asyncTest('should be able to handle changes belonging to different tables', () =
     .then((objects) => {
       // Works with auto-incremented key
       strictEqual(objects[0].foo, barCreateChange.obj.foo, 'barCreateChange found in table');
+    })
+    .catch(function(err) {
+      ok(false, "Error: " + err);
+    })
+    .finally(start);
+});
+
+asyncTest('should be able to handle large number of changes', () => {
+  let changes = [];
+  for( let i = 0; i < 10000; i++ ) {
+    changes.push({key : i, table: "foo",  obj: { id: i, foo: "bar" }, type: CREATE});
+  }
+  applyChanges(changes)
+    .then(() => {
+      ok(true, "Tests passed!");
     })
     .catch(function(err) {
       ok(false, "Error: " + err);


### PR DESCRIPTION
This pull request changes apply-changes to use a transaction to manage changes instead of using
chained promises.

This is to mitigate #569 as promises seem to behave badly in the presence of a large number (~18k) of changes.