### PR TITLE
Include safari and smartphones in test suite

### DIFF
--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -2085,11 +2085,8 @@ export default function Dexie(dbName, options) {
                 function union(item, cursor, advance) {
                     if (!filter || filter(cursor, advance, resolveboth, reject)) {
                         var primaryKey = cursor.primaryKey;
-                        var key = ''+(ArrayBuffer && (primaryKey instanceof ArrayBuffer) ?
-                            new Uint8Array(primaryKey) : // Converts ArrayBuffer to comma-separated list of bytes
-                            primaryKey // Converts any Date to String, String to String, Number to String and Array to comma-separated string
-                        );
-                        
+                        var key = '' + primaryKey;
+                        if (key === '[object ArrayBuffer]') key = '' + new Uint8Array(primaryKey);
                         if (!hasOwn(set, key)) {
                             set[key] = true;
                             fn(item, cursor, advance);

--- a/src/utils.js
+++ b/src/utils.js
@@ -219,7 +219,8 @@ export function getObjectDiff(a, b, rv, prfx) {
                 bp = b[prop];
             if (typeof ap === 'object' && typeof bp === 'object' &&
                     ap && bp &&
-                    ap.constructor === bp.constructor)
+                    // Now compare constructors are same (not equal because wont work in Safari)
+                    (''+ap.constructor) === (''+bp.constructor))
                 // Same type of object but its properties may have changed
                 getObjectDiff (ap, bp, rv, prfx + prop + ".");
             else if (ap !== bp)

--- a/test/karma.browsers.matrix.js
+++ b/test/karma.browsers.matrix.js
@@ -14,18 +14,24 @@ module.exports = {
     
     // Continous Integration on every push to master
     ci: [
-        'bs_firefox_latest_supported',
-        'bs_ie11'
+        // - Let firefox represent the standard evergreen browser.
+        // Leaving out Chrome, since local tests have hopefully already run on it.
+        // Chrome will be tested in the pre_npm_publish anyway.
+        'bs_firefox_latest_supported', 
+        // Internet Explorer - an old beast. Enforces legacy compatibility for every PR!
+        'bs_ie11',  
+        // Safari 10.1 - another beast. Enforces native Safari support for every PR!
+        'bs_iphone7'
     ],
 
     // Test matrix used before every npm publish.
     pre_npm_publish: [
-        //'bs_chrome_oldest_supported',
-        //'bs_chrome_latest_supported',
-        //'bs_firefox_oldest_supported',
-        //'bs_firefox_latest_supported',
-        //'bs_edge_latest_supported', // Know that edge has been sporadically instable. Might be better on Edge 15 or later. Restart of tests often needed.
-        //'bs_safari',
+        'bs_chrome_oldest_supported',
+        'bs_chrome_latest_supported',
+        'bs_firefox_oldest_supported',
+        'bs_firefox_latest_supported',
+        'bs_edge_latest_supported', // Know that edge has been sporadically instable. Might be better on Edge 15 or later. Restart of tests often needed.
+        'bs_safari',
         "bs_iphone7"
     ]
 }

--- a/test/karma.browsers.matrix.js
+++ b/test/karma.browsers.matrix.js
@@ -20,10 +20,12 @@ module.exports = {
 
     // Test matrix used before every npm publish.
     pre_npm_publish: [
-        'bs_chrome_oldest_supported',
-        'bs_chrome_latest_supported',
-        'bs_firefox_oldest_supported',
-        'bs_firefox_latest_supported',
-        'bs_edge_latest_supported' // Know that edge has been sporadically instable. Might be better on Edge 15 or later. Restart of tests often needed.
+        //'bs_chrome_oldest_supported',
+        //'bs_chrome_latest_supported',
+        //'bs_firefox_oldest_supported',
+        //'bs_firefox_latest_supported',
+        //'bs_edge_latest_supported', // Know that edge has been sporadically instable. Might be better on Edge 15 or later. Restart of tests often needed.
+        //'bs_safari',
+        "bs_iphone7"
     ]
 }

--- a/test/karma.browserstack.js
+++ b/test/karma.browserstack.js
@@ -53,6 +53,20 @@ module.exports = {
       browser_version: "60",
       os: 'Windows',
       os_version: 10
+    },
+    bs_safari: {
+      base: 'BrowserStack',
+      browser: "Safari",
+      browser_version: "10.1",
+      os: 'OS X',
+      os_version: 'Sierra'
+    },
+    bs_iphone7: {
+      base: 'BrowserStack',
+      browser: "Safari",
+      browser_version: "10.1",
+      os: 'iOS',
+      os_version: "10.3"
     }
   }
 }

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -83,8 +83,12 @@ spawnedTest("#248 'modifications' object in 'updating' hook can be bizarre", fun
             return {date: new Date(date._year, date._month, date._day)};
         }
     }
+    function isDate(obj) {
+        // obj instanceof Date does NOT work with Safari when Date are retrieved from IDB.
+        return obj.getTime && obj.getDate && obj.getFullYear;
+    }
     function readingHook (obj) {
-        if (obj.date && obj.date instanceof Date) {
+        if (obj.date && isDate(obj.date)) {
             obj.date = new CustomDate(obj.date);
         }
         return obj;

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -104,10 +104,16 @@ rm -rf addons/*/dist/*
 
 # build
 npm run build
-
+   
 # test
-printf "Testing on browserstack\n"
-npm run test
+printf "Testing on browserstack (will retry up to 4 times)\n"
+n=0
+until [ $n -ge 4 ]
+do
+  npm run test && break
+  n=$[$n+1]
+  printf "Browserstack tests failed.\n"
+done
 
 printf "Browserstack tests for Dexie.js passed.\n"
 
@@ -128,9 +134,15 @@ do
     printf "Installing dependencies for ${addonNpmName}"
     npm install
 
-    printf "Building and testing ${addon} on browserstack\n"
+    printf "Building and testing ${addon} on browserstack (will retry up to 4 times)\n"
 
-    npm run test
+    n=0
+    until [ $n -ge 4 ]
+    do
+      npm run test && break
+      n=$[$n+1]
+      printf "${addon} Browserstack tests failed.\n"
+    done
 
     printf "${addon} Browserstack tests passed.\n"
     


### PR DESCRIPTION
Resolves #230.

At last! This PR adds Iphone7/Safari 10.1 to the CI integration tests and pre-publish tests. There were 7 failing unit tests in Safari that has been fixed/worked around with this commit. To summarize them:

1. Objects retrieved from IDB seem to live in their own realm, so for example, it was not safe to check for (obj.dateColumn instanceof Date) as it is instance of the Date object in the foreign realm.
2. IDB/Promise compatibility: Native promises and IndexedDB actually plays ball in Safari, but you need to let IDB do the kick-off! As soon as a transaction has been created it has to be utilized before leaving the micro-tick. Some tests in native async/await support failed due to this limitation, but they could easlily be worked around by leading every transaction with a `await db.items.get(1)`.
