### PR TITLE
Partially revert pr 579

### DIFF
--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -2787,8 +2787,9 @@ export default function Dexie(dbName, options) {
         for (var i = 0; i < storeNames.length; ++i) {
             var storeName = storeNames[i];
             var store = idbtrans.objectStore(storeName);
-            hasGetAll = navigator.userAgent.indexOf("Safari") === -1 && // See issue #565
-                'getAll' in store;
+            hasGetAll = 'getAll' in store &&
+                !(/Apple/.test(navigator.vendor) &&
+                  [].concat(navigator.userAgent.match(/Safari\/(\d*)/))[1] < 604); // See issue #565 and PR #579
             for (var j = 0; j < store.indexNames.length; ++j) {
                 var indexName = store.indexNames[j];
                 var keyPath = store.index(indexName).keyPath;

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -2784,12 +2784,12 @@ export default function Dexie(dbName, options) {
         /// <param name="schema" type="Object">Map between name and TableSchema</param>
         /// <param name="idbtrans" type="IDBTransaction"></param>
         var storeNames = idbtrans.db.objectStoreNames;
+
         for (var i = 0; i < storeNames.length; ++i) {
             var storeName = storeNames[i];
             var store = idbtrans.objectStore(storeName);
-            hasGetAll = 'getAll' in store &&
-                !(/Apple/.test(navigator.vendor) &&
-                  [].concat(navigator.userAgent.match(/Safari\/(\d*)/))[1] < 604); // See issue #565 and PR #579
+            hasGetAll = 'getAll' in store;
+            
             for (var j = 0; j < store.indexNames.length; ++j) {
                 var indexName = store.indexNames[j];
                 var keyPath = store.index(indexName).keyPath;
@@ -2800,6 +2800,15 @@ export default function Dexie(dbName, options) {
                 }
             }
         }
+
+        // Bug with getAll() on Safari ver<604 on Workers only, see discussion following PR #579
+        if (/Safari/.test(navigator.userAgent) &&
+            !/Chrome/.test(navigator.userAgent) &&
+            _global.WorkerGlobalScope && _global instanceof _global.WorkerGlobalScope &&
+            [].concat(navigator.userAgent.match(/Safari\/(\d*)/))[1] < 604)
+        {
+            hasGetAll = false;
+        }    
     }
 
     function fireOnBlocked(ev) {

--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -2803,7 +2803,7 @@ export default function Dexie(dbName, options) {
 
         // Bug with getAll() on Safari ver<604 on Workers only, see discussion following PR #579
         if (/Safari/.test(navigator.userAgent) &&
-            !/Chrome/.test(navigator.userAgent) &&
+            !/(Chrome\/|Edge\/)/.test(navigator.userAgent) &&
             _global.WorkerGlobalScope && _global instanceof _global.WorkerGlobalScope &&
             [].concat(navigator.userAgent.match(/Safari\/(\d*)/))[1] < 604)
         {

--- a/test/tests-open.js
+++ b/test/tests-open.js
@@ -268,6 +268,11 @@ asyncTest("Issue #76 Dexie inside Web Worker", function () {
                 ok(true, "Could create a transaction");
                 db.table1.add({ name: "My first object" }).then(function(id) {
                     ok(true, "Could add object that got id " + id);
+                    // Verify we workaround Safari issues with getAll() in workers
+                    // ... as discussed in PR #579.
+                    return db.table1.toArray();
+                }).then(function(){
+                    ok(true, "Could all toArray() on a table (verified workaround for Safari 10.1 issue with getAll())");
                 }).catch(function(err) {
                     ok(false, "Got error: " + err);
                 });


### PR DESCRIPTION
PR #579 was meant to work around a severe Safari issue with IDBObjectStore.getAll() that when called from a Web worker, results in a page crash followed by an automatic page reload. Since getAll() is just an optimization and not needed for IndexedDB to work, PR 579 shut down this optimization of utilizing on Safari. Due to the nature of the Safari bug (page crash + reload), feature testing was not possible - we could only do user-agent sniffing to avoid the bug.

The user-agent sniffing in PR  #579 did only look for "Safari" in user-agent, which made it also affect Chrome and Opera browsers (which was not the intent). Also, the bug has since been fixed in a later version of Safari + it only happened when called from a web worker, so we needed a more fine grained control of whether the getAll() optimization should be avoided or not. 

This new PR will replace the user-agent code from PR #579 with another more fine grained check that only disables getAll() when:

* browser is Safari (user agent contains "Safari" but not "Chrome" or "Edge")
* we are in a Worker environment
* Safari internal version number is less than 604, as the issue has been fixed in 604.
