### PR TITLE
fix for removing array items

### DIFF
--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -141,14 +141,20 @@ export function setByKeyPath(obj, keyPath, value) {
             var currentKeyPath = keyPath.substr(0, period);
             var remainingKeyPath = keyPath.substr(period + 1);
             if (remainingKeyPath === "")
-                if (value === undefined) delete obj[currentKeyPath]; else obj[currentKeyPath] = value;
+                if (value === undefined) {
+                    if (isArray(obj) && !isNaN(parseInt(currentKeyPath))) obj.splice(currentKeyPath, 1);
+                    else delete obj[currentKeyPath];
+                } else obj[currentKeyPath] = value;
             else {
                 var innerObj = obj[currentKeyPath];
                 if (!innerObj) innerObj = (obj[currentKeyPath] = {});
                 setByKeyPath(innerObj, remainingKeyPath, value);
             }
         } else {
-            if (value === undefined) delete obj[keyPath]; else obj[keyPath] = value;
+            if (value === undefined) {
+                if (isArray(obj) && !isNaN(parseInt(keyPath))) obj.splice(keyPath, 1);
+                else delete obj[keyPath];
+            } else obj[keyPath] = value;
         }
     }
 }


### PR DESCRIPTION
Using Dexie.delByKeyPath(), which ultimately calls Dexie.setByKeyPath(), causes some problems when the path ends in an array.

Removing an item from an array using delete does not updating the array length. Instead it creates an undefined array item, leaving the length alone.

This fix identifies the object as an Array and uses Array.splice() to remove the keyPath.

See here: [delete operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete) under Deleting Array Elements.

