### PR TITLE
fix for setByKeyPath when removing array items

### DIFF
--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -141,14 +141,20 @@ export function setByKeyPath(obj, keyPath, value) {
             var currentKeyPath = keyPath.substr(0, period);
             var remainingKeyPath = keyPath.substr(period + 1);
             if (remainingKeyPath === "")
-                if (value === undefined) delete obj[currentKeyPath]; else obj[currentKeyPath] = value;
-            else {
+            if (value === undefined) {
+                if (isArray(obj) && !isNaN(parseInt(currentKeyPath))) obj.splice(currentKeyPath, 1);
+                else delete obj[currentKeyPath];
+            } else obj[currentKeyPath] = value;
+        else {
                 var innerObj = obj[currentKeyPath];
                 if (!innerObj) innerObj = (obj[currentKeyPath] = {});
                 setByKeyPath(innerObj, remainingKeyPath, value);
             }
         } else {
-            if (value === undefined) delete obj[keyPath]; else obj[keyPath] = value;
+            if (value === undefined) {
+                if (isArray(obj) && !isNaN(parseInt(keyPath))) obj.splice(keyPath, 1);
+                else delete obj[keyPath];
+            } else obj[keyPath] = value;
         }
     }
 }

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -196,3 +196,14 @@ spawnedTest ("#360 DB unresponsive after multiple Table.update() or Collection.m
     });
     equal(result.value, NUM_UPDATES, `Should have updated id 1 a ${NUM_UPDATES} times`);
 });
+
+spawnedTest ("delByKeyPath not working correctly for arrays", function* () {
+    const obj = {deepObject: {someArray: ["a", "b"]}};
+    const obj2 = {deepObject: {someArray: ["a", "b", "c"]}};
+    const jsonResult = JSON.stringify(obj);
+    console.log("jsonResult = ", jsonResult);
+    Dexie.delByKeyPath(obj2, "deepObject.someArray.2");
+    const jsonResult2 = JSON.stringify(obj2);
+    console.log("jsonResult2 = ", jsonResult2);
+    equal(jsonResult, jsonResult2, `Should be equal ${jsonResult} ${jsonResult2}`);
+});


### PR DESCRIPTION
I ran into an issue (using 2.0.2) with Dexie.Observable. When receiving the UPDATED changes event, the object returns was not the same as the object in the database. Tracing it down, I found an issue with the way deletes were applied.

Using Dexie.delByKeyPath(), which ultimately calls Dexie.setByKeyPath(), causes some problems when the path ends in an array.

Removing an item from an array using delete does not updating the array length. Instead it creates an undefined array item, leaving the length alone. Essentially, this means that:

```
const obj = {deepObject: {someArray: ["a", "b", "c"]}};
Dexie.delByKeyPath(obj, "deepObject.someArray.2");
```
results in:
```
obj === {deepObject: {someArray: ["a", "b", null]}};
```
instead of 
```
obj === {deepObject: {someArray: ["a", "b"]}};
```

This fix identifies the object as an Array and uses Array.splice() to remove the keyPath.

See here: [delete operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete) under Deleting Array Elements for additional understanding of the problem.


