### PR TITLE
Updated dts-bundle-generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
       "node ../tools/replaceVersionAndDate.js ../dist/dexie.js",
       "node ../tools/replaceVersionAndDate.js ../dist/dexie.mjs",
       "dts-bundle-generator --umd-module-name Dexie -o ../dist/dexie.d.ts public/index.d.ts",
-      "node ../tools/append.js ../dist/dexie.d.ts ../tools/build-configs/export-default-dexie.txt",
       "node ../tools/prepend.js ../dist/dexie.d.ts ../tools/build-configs/banner.txt",
       "node ../tools/replaceVersionAndDate.js ../dist/dexie.d.ts"
     ],
@@ -87,7 +86,7 @@
   },
   "homepage": "http://dexie.org",
   "devDependencies": {
-    "dts-bundle-generator": "^0.6.1",
+    "dts-bundle-generator": "^1.0.0",
     "just-build": "^0.9.16",
     "karma": "^1.7.1",
     "karma-browserstack-launcher": "^1.1.1",

--- a/src/public/index.d.ts
+++ b/src/public/index.d.ts
@@ -48,8 +48,5 @@ export { IndexableType } from './types/indexable-type';
 export { Dexie };
 
 /** Exporting 'Dexie' as the default export.
- * NOTE: This line is ignored by dts-bundle-generator, so it has to be
- * manyally inserted in build script (package.json:"just-build"/"dexie")
- * Still, keeping it here for clarity.
  **/
 export default Dexie;

--- a/tools/append.js
+++ b/tools/append.js
@@ -1,8 +1,0 @@
-const fs = require('fs');
-const args = process.argv.slice(2);
-const [file, appentionArg] = args.filter(arg => arg[0] !== '-');
-const isText = args.some(arg => arg === '--text');
-
-const appention = isText ? appentionArg : fs.readFileSync(appentionArg);
-
-fs.appendFileSync(file, appention);

--- a/tools/build-configs/export-default-dexie.txt
+++ b/tools/build-configs/export-default-dexie.txt
@@ -1,2 +1,0 @@
-
-export default Dexie;


### PR DESCRIPTION
Hi there!

[I just released](https://github.com/timocov/dts-bundle-generator/releases/tag/v1.0.0) new version of `dts-bundle-generator` where I have fixed the bug when `export default` is removed from output - so you do not need to append it by yourself anymore 🙂 .

As soon `package-lock.json` is OS-dependent I am not sure how to update it right way. If you want - I can just push all changes made by my local `npm`.