### PR TITLE
Make sure navigator is available in our context before using it

### DIFF
--- a/src/classes/version/schema-helpers.ts
+++ b/src/classes/version/schema-helpers.ts
@@ -280,7 +280,7 @@ export function adjustToExistingIndexNames(db: Dexie, schema: DbSchema, idbtrans
   }
 
   // Bug with getAll() on Safari ver<604 on Workers only, see discussion following PR #579
-  if (/Safari/.test(navigator.userAgent) &&
+  if (typeof navigator !== 'undefined' && /Safari/.test(navigator.userAgent) &&
       !/(Chrome\/|Edge\/)/.test(navigator.userAgent) &&
       _global.WorkerGlobalScope && _global instanceof _global.WorkerGlobalScope &&
       [].concat(navigator.userAgent.match(/Safari\/(\d*)/))[1] < 604)


### PR DESCRIPTION
Hi,

I recently encountered an exception where Dexie would try to access `navigator`, which was not available. I see that in the codebase it is usually checked that `navigator` is available before using, except in one place. So I added this check and it solves my issue.

I did not understand 100% the issue, but it seemed to happen while initializing a new version of a Dexie database with an extra table.

Cheers,
Rémi
