### PR TITLE
Update the readme.md to support 2.7 with strictPropertyInitialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ interface IFriend {
 // Declare Database
 //
 class FriendDatabase extends Dexie {
-    friends: Dexie.Table<IFriend,number>;
+    public friends!: Dexie.Table<IFriend,number>;
 
-    constructor() {
+    public constructor() {
         super("FriendDatabase");
         this.version(1).stores({
             friends: "++id,name,age"
@@ -167,7 +167,7 @@ class FriendDatabase extends Dexie {
     }
 }
 
-var db = new FriendDatabase();
+const db = new FriendDatabase();
 
 db.transaction('rw', db.friends, async() => {
 


### PR DESCRIPTION
TypeScript 2.7 with strictPropertyInitialization to true require specifying that a member will be initialized later (lazy-initialized). This is the case and it won't compile without the exclamation point to anyone having this strict policy turned on. The code will also work for people with the flag off. It would be clearer if the readme had it.