### PR TITLE
Resolve #617

### DIFF
--- a/src/Dexie.js
+++ b/src/Dexie.js
@@ -3184,10 +3184,12 @@ dbNamesDB.version(1).stores({dbnames: 'name'});
 (()=>{
     // Migrate from Dexie 1.x database names stored in localStorage:
     var DBNAMES = 'Dexie.DatabaseNames';
-    if (typeof localStorage !== undefined && _global.document !== undefined) try {
-        // Have localStorage and is not executing in a worker. Lets migrate from Dexie 1.x.
-        JSON.parse(localStorage.getItem(DBNAMES) || "[]")
-            .forEach(name => dbNamesDB.dbnames.put({name: name}).catch(nop));
-        localStorage.removeItem(DBNAMES);
+    try { // https://github.com/dfahlander/Dexie.js/issues/617
+        if (typeof localStorage !== undefined && _global.document !== undefined) {
+            // Have localStorage and is not executing in a worker. Lets migrate from Dexie 1.x.
+            JSON.parse(localStorage.getItem(DBNAMES) || "[]")
+                .forEach(name => dbNamesDB.dbnames.put({name: name}).catch(nop));
+            localStorage.removeItem(DBNAMES);
+        }
     } catch (_e) {}
 })();


### PR DESCRIPTION
Move the try statement up in order to cache invalid access of localStorage.

In 3.0, this whole last block of backward-compliant is removed. It is very non-cruzial. Was tempted to remove it in its whole in master-2 (2.x branch), but ... 2.0 is on maintainance and want to change as little as possible...
