### PR TITLE
Update dts-bundle-generator to skip "broken" version (1.2.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -860,9 +860,9 @@
       "optional": true
     },
     "dts-bundle-generator": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-1.2.0.tgz",
-      "integrity": "sha512-5vcjy5pwrsX/bS68s8c/WLGV1aFU39Dq8GOzlq2wXO/Aw/zEfosW/KrHDiOu7k7LKOs00iKQglFgxupwhQ7zAg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-1.2.2.tgz",
+      "integrity": "sha512-ZBVDA/QfBar5CLpvw9X/MH7zBREZK8qyL48AZBZXNdvaqDhTERFlrT6snZlM+iZMaGSiJynT+CsGvSQKYNM58g==",
       "dev": true,
       "requires": {
         "typescript": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "homepage": "http://dexie.org",
   "devDependencies": {
-    "dts-bundle-generator": "1.2.0",
+    "dts-bundle-generator": "^1.2.2",
     "just-build": "^0.9.16",
     "karma": "^2.0.2",
     "karma-browserstack-launcher": "^1.1.1",


### PR DESCRIPTION
Sorry for 1.2.1 - it has accidentally merge commit which reverts back some changes (which should not be in the master) (see https://github.com/timocov/dts-bundle-generator/commit/02b8c38adcbe53a058f5ab71672c8b0f5bb8a855).

Now it works fine.