### PR TITLE
Fix Dexie delete database regression on Node.js

### DIFF
--- a/src/classes/dexie/dexie.ts
+++ b/src/classes/dexie/dexie.ts
@@ -263,7 +263,7 @@ export class Dexie implements IDexie {
     return new Promise((resolve, reject) => {
       const doDelete = () => {
         this.close();
-        var req = indexedDB.deleteDatabase(this.name);
+        var req = this._deps.indexedDB.deleteDatabase(this.name);
         req.onsuccess = wrap(() => {
           databaseEnumerator.remove(this.name);
           resolve();


### PR DESCRIPTION
The `delete()` method was using the global reference to `indexedDB` which both violates encapsulation and does not exist if you are using Dexie in node and injecting the indexedDB reference directly into its dependencies object.

Fix: Replace the global reference to `indexedDB` with a reference to the indexedDB database from the instance’s `_deps` property.

Note: this is currently not caught by the browser-based unit tests as this is not an issue that manifests in the browser.

Fixes #703 