### PR TITLE
Nulled lastKey when table to export is empty.

### DIFF
--- a/addons/dexie-export-import/src/export.ts
+++ b/addons/dexie-export-import/src/export.ts
@@ -140,7 +140,9 @@ export async function exportDB(db: Dexie, options?: ExportOptions): Promise<Blob
           // By generating a blob here, we give web platform the opportunity to store the contents
           // on disk and release RAM.
           slices.push(new Blob([json.substring(1, json.length - 1)]));
-          lastKey = Dexie.getByKeyPath(values[values.length -1], primKey.keyPath as string);
+          lastKey = values.length > 0 ?
+            Dexie.getByKeyPath(values[values.length -1], primKey.keyPath as string) :
+            null;
         } else {
           const keys = await chunkedCollection.primaryKeys();
           let keyvals = keys.map((key, i) => [key, values[i]]);
@@ -163,7 +165,9 @@ export async function exportDB(db: Dexie, options?: ExportOptions): Promise<Blob
               slices.push("\n      ");
             }
           }
-          lastKey = keys[keys.length - 1];
+          lastKey = keys.length > 0 ?
+            keys[keys.length - 1] :
+            null;
         }
         progress.completedRows += values.length;
       }


### PR DESCRIPTION
Following from https://github.com/dfahlander/Dexie.js/issues/777, this allows exports to continue without errors when tables are present but have no entries.