### PR TITLE
fallback on Promise

### DIFF
--- a/src/helpers/promise.js
+++ b/src/helpers/promise.js
@@ -762,7 +762,7 @@ function switchToZone (targetZone, bEnteringZone) {
 }
 
 function snapShot () {
-    var GlobalPromise = _global.Promise;
+    var GlobalPromise = _global.Promise || Promise;
     return patchGlobalPromise ? {
         Promise: GlobalPromise,
         PromiseProp: Object.getOwnPropertyDescriptor(_global, "Promise"),


### PR DESCRIPTION
When building against esNext window.Promise, Node.Promise etc. do not seem to exist, resulting in a runtime error in the code when running on Node.  While this change could be regarded as a hack, it allows Dexie to run.