### PR TITLE
ESNext compatibility

### DIFF
--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -1,10 +1,12 @@
 ﻿declare var global;
 export const keys = Object.keys;
 export const isArray = Array.isArray;
-export const _global =
+const _global =
     typeof self !== 'undefined' ? self :
     typeof window !== 'undefined' ? window :
     global;
+_global.Promise = Promise;
+export { _global }
 
 export function extend(obj, extension) {
     if (typeof extension !== 'object') return obj;

--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -5,7 +5,9 @@ const _global =
     typeof self !== 'undefined' ? self :
     typeof window !== 'undefined' ? window :
     global;
-_global.Promise = Promise;
+if (!_global.Promise){
+    _global.Promise = Promise;
+}
 export { _global }
 
 export function extend(obj, extension) {

--- a/src/helpers/promise.js
+++ b/src/helpers/promise.js
@@ -44,7 +44,7 @@ const
     nativePromiseInstanceAndProto = (()=>{
         try {
             // Be able to patch native async functions
-            return new Function(`let F=async ()=>{},p=F();return [p,Object.getPrototypeOf(p),Promise.resolve(),F.constructor];`)();
+            return new Function('let F=async ()=>{},p=F();return [p,Object.getPrototypeOf(p),Promise.resolve(),F.constructor];')();
         } catch(e) {
             var P = _global.Promise;
             return P ?


### PR DESCRIPTION
I think this will meet requirements for #811. It is in 2 commits (which I would advise squashing if you accept pull request). I ran all tests with the 1st commit, and all passed. 

I think this is attaching the _global (ECMAScript) Promise high enough in the dependency chain that it is the native Promise implementation being added. I would assume if I was attaching the Dexie.promise at the wrong stage to the _global.Promise, the tests would fail after the 1st commit.

I also change template literal (back tick) to simple string as I think it is slightly more readable - I kept looking for the ${ insertion point, which wasn't there.

Thanks for creating this great library by the way.