### PR TITLE
Fix #812 for IE11

### DIFF
--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -5,7 +5,7 @@ const _global =
     typeof self !== 'undefined' ? self :
     typeof window !== 'undefined' ? window :
     global;
-if (!_global.Promise){
+if (typeof Promise === 'object' && !_global.Promise){
     _global.Promise = Promise;
 }
 export { _global }


### PR DESCRIPTION
Old browsers that do not have Promise on window seems to fail. Fixing by verifying typeof Promise === 'object' before applying the #812 workaround.