### PR TITLE
Own deepEqual() required for Safari

### DIFF
--- a/addons/Dexie.Observable/test/unit/deep-equal.js
+++ b/addons/Dexie.Observable/test/unit/deep-equal.js
@@ -2,5 +2,20 @@ import {equal} from 'QUnit';
 
 // Must use this rather than QUnit's deepEqual() because that one fails on Safari when run via karma-browserstack-launcher
 export function deepEqual(a, b, description) {
-  equal(JSON.stringify(a, null, 2), JSON.stringify(b, null, 2), description);
+  if (typeof a === 'object' && typeof b === 'object' && a != null && b != null) {
+    equal(JSON.stringify(sortMembers(a), null, 2), JSON.stringify(sortMembers(b), null, 2), description);
+  } else {
+    equal(JSON.stringify(a, null, 2), JSON.stringify(b, null, 2), description);
+  }
+}
+
+/**
+ * 
+ * @param {object} obj 
+ */
+function sortMembers (obj) {
+  return Object.keys(obj).sort().reduce((result, key) => {
+    result[key] = obj[key];
+    return result;
+  }, {});
 }

--- a/addons/Dexie.Observable/test/unit/deep-equal.js
+++ b/addons/Dexie.Observable/test/unit/deep-equal.js
@@ -1,0 +1,6 @@
+import {equal} from 'QUnit';
+
+// Must use this rather than QUnit's deepEqual() because that one fails on Safari when run via karma-browserstack-launcher
+export function deepEqual(a, b, description) {
+  equal(JSON.stringify(a, null, 2), JSON.stringify(b, null, 2), description);
+}

--- a/addons/Dexie.Observable/test/unit/hooks/tests-creating.js
+++ b/addons/Dexie.Observable/test/unit/hooks/tests-creating.js
@@ -1,5 +1,6 @@
 import Dexie from 'dexie';
-import {module, asyncTest, start, stop, strictEqual, deepEqual, ok} from 'QUnit';
+import {module, asyncTest, start, stop, strictEqual, ok} from 'QUnit';
+import {deepEqual} from '../deep-equal';
 import {resetDatabase} from '../../../../../test/dexie-unittest-utils';
 import initCreatingHook from '../../../src/hooks/creating';
 import initWakeupObservers from '../../../src/wakeup-observers';

--- a/addons/Dexie.Observable/test/unit/hooks/tests-deleting.js
+++ b/addons/Dexie.Observable/test/unit/hooks/tests-deleting.js
@@ -1,5 +1,6 @@
 import Dexie from 'dexie';
-import {module, asyncTest, start, stop, strictEqual, deepEqual, ok} from 'QUnit';
+import {module, asyncTest, start, stop, strictEqual, ok} from 'QUnit';
+import {deepEqual} from '../deep-equal';
 import {resetDatabase} from '../../../../../test/dexie-unittest-utils';
 import initDeletingHook from '../../../src/hooks/deleting';
 import initWakeupObservers from '../../../src/wakeup-observers';

--- a/addons/Dexie.Observable/test/unit/hooks/tests-updating.js
+++ b/addons/Dexie.Observable/test/unit/hooks/tests-updating.js
@@ -1,5 +1,6 @@
 import Dexie from 'dexie';
-import {module, asyncTest, start, stop, strictEqual, deepEqual, ok} from 'QUnit';
+import {module, asyncTest, start, stop, strictEqual, ok} from 'QUnit';
+import {deepEqual} from '../deep-equal';
 import {resetDatabase} from '../../../../../test/dexie-unittest-utils';
 import initUpdatingHook from '../../../src/hooks/updating';
 import initWakeupObservers from '../../../src/wakeup-observers';

--- a/addons/Dexie.Observable/test/unit/tests-observable-misc.js
+++ b/addons/Dexie.Observable/test/unit/tests-observable-misc.js
@@ -1,4 +1,5 @@
-﻿import {module, asyncTest, equal, strictEqual, deepEqual, ok, start} from 'QUnit';
+﻿import {module, asyncTest, equal, strictEqual, ok, start} from 'QUnit';
+import {deepEqual} from './deep-equal';
 import Dexie from 'dexie';
 import 'dexie-observable';
 

--- a/test/karma.browserstack.js
+++ b/test/karma.browserstack.js
@@ -1,7 +1,8 @@
 module.exports = {
   browserStack: {
     username: process.env.BROWSER_STACK_USERNAME,
-    accessKey: process.env.BROWSER_STACK_ACCESS_KEY
+    accessKey: process.env.BROWSER_STACK_ACCESS_KEY,
+    timeout: 1800
   },
 
   customLaunchers: {


### PR DESCRIPTION
Safari returns objects from IndexedDB from another realm so QUnit's deepEqual() returns false also when the content is identical. Need a custom deepEqual() in some unit tests so that the tests pass.
