### PR TITLE
Change typings to allow for compound keys

### DIFF
--- a/src/public/types/where-clause.d.ts
+++ b/src/public/types/where-clause.d.ts
@@ -5,14 +5,14 @@ import { IndexableType } from "./indexable-type";
 export interface WhereClause<T=any, TKey=IndexableType> {
   above(key: any): Collection<T, TKey>;
   aboveOrEqual(key: any): Collection<T, TKey>;
-  anyOf(keys: IndexableTypeArrayReadonly): Collection<T, TKey>;
-  anyOf(...keys: IndexableTypeArray): Collection<T, TKey>;
+  anyOf(keys: ReadonlyArray<TKey>): Collection<T, TKey>;
+  anyOf(...keys: Array<TKey>): Collection<T, TKey>;
   anyOfIgnoreCase(keys: string[]): Collection<T, TKey>;
   anyOfIgnoreCase(...keys: string[]): Collection<T, TKey>;
   below(key: any): Collection<T, TKey>;
   belowOrEqual(key: any): Collection<T, TKey>;
   between(lower: any, upper: any, includeLower?: boolean, includeUpper?: boolean): Collection<T, TKey>;
-  equals(key: any): Collection<T, TKey>;
+  equals(key: TKey): Collection<T, TKey>;
   equalsIgnoreCase(key: string): Collection<T, TKey>;
   inAnyRange(ranges: ReadonlyArray<{0: any, 1: any}>, options?: { includeLowers?: boolean, includeUppers?: boolean }): Collection<T, TKey>;
   startsWith(key: string): Collection<T, TKey>;
@@ -21,6 +21,6 @@ export interface WhereClause<T=any, TKey=IndexableType> {
   startsWithIgnoreCase(key: string): Collection<T, TKey>;
   startsWithAnyOfIgnoreCase(prefixes: string[]): Collection<T, TKey>;
   startsWithAnyOfIgnoreCase(...prefixes: string[]): Collection<T, TKey>;
-  noneOf(keys: Array<any>): Collection<T, TKey>;
-  notEqual(key: any): Collection<T, TKey>;
+  noneOf(keys: ReadonlyArray<TKey>): Collection<T, TKey>;
+  notEqual(key: TKey): Collection<T, TKey>;
 }

--- a/src/public/types/where-clause.d.ts
+++ b/src/public/types/where-clause.d.ts
@@ -5,14 +5,14 @@ import { IndexableType } from "./indexable-type";
 export interface WhereClause<T=any, TKey=IndexableType> {
   above(key: any): Collection<T, TKey>;
   aboveOrEqual(key: any): Collection<T, TKey>;
-  anyOf(keys: ReadonlyArray<TKey>): Collection<T, TKey>;
-  anyOf(...keys: Array<TKey>): Collection<T, TKey>;
+  anyOf(keys: ReadonlyArray<IndexableType | TKey>): Collection<T, TKey>;
+  anyOf(...keys: Array<IndexableType | TKey>): Collection<T, TKey>;
   anyOfIgnoreCase(keys: string[]): Collection<T, TKey>;
   anyOfIgnoreCase(...keys: string[]): Collection<T, TKey>;
   below(key: any): Collection<T, TKey>;
   belowOrEqual(key: any): Collection<T, TKey>;
   between(lower: any, upper: any, includeLower?: boolean, includeUpper?: boolean): Collection<T, TKey>;
-  equals(key: TKey): Collection<T, TKey>;
+  equals(key: IndexableType | TKey): Collection<T, TKey>;
   equalsIgnoreCase(key: string): Collection<T, TKey>;
   inAnyRange(ranges: ReadonlyArray<{0: any, 1: any}>, options?: { includeLowers?: boolean, includeUppers?: boolean }): Collection<T, TKey>;
   startsWith(key: string): Collection<T, TKey>;
@@ -21,6 +21,6 @@ export interface WhereClause<T=any, TKey=IndexableType> {
   startsWithIgnoreCase(key: string): Collection<T, TKey>;
   startsWithAnyOfIgnoreCase(prefixes: string[]): Collection<T, TKey>;
   startsWithAnyOfIgnoreCase(...prefixes: string[]): Collection<T, TKey>;
-  noneOf(keys: ReadonlyArray<TKey>): Collection<T, TKey>;
-  notEqual(key: TKey): Collection<T, TKey>;
+  noneOf(keys: ReadonlyArray<IndexableType | TKey>): Collection<T, TKey>;
+  notEqual(key: IndexableType | TKey): Collection<T, TKey>;
 }

--- a/src/public/types/where-clause.d.ts
+++ b/src/public/types/where-clause.d.ts
@@ -5,14 +5,14 @@ import { IndexableType } from "./indexable-type";
 export interface WhereClause<T=any, TKey=IndexableType> {
   above(key: any): Collection<T, TKey>;
   aboveOrEqual(key: any): Collection<T, TKey>;
-  anyOf(keys: ReadonlyArray<IndexableType | TKey>): Collection<T, TKey>;
-  anyOf(...keys: Array<IndexableType | TKey>): Collection<T, TKey>;
+  anyOf(keys: ReadonlyArray<IndexableType>): Collection<T, TKey>;
+  anyOf(...keys: Array<IndexableType>): Collection<T, TKey>;
   anyOfIgnoreCase(keys: string[]): Collection<T, TKey>;
   anyOfIgnoreCase(...keys: string[]): Collection<T, TKey>;
   below(key: any): Collection<T, TKey>;
   belowOrEqual(key: any): Collection<T, TKey>;
   between(lower: any, upper: any, includeLower?: boolean, includeUpper?: boolean): Collection<T, TKey>;
-  equals(key: IndexableType | TKey): Collection<T, TKey>;
+  equals(key: IndexableType): Collection<T, TKey>;
   equalsIgnoreCase(key: string): Collection<T, TKey>;
   inAnyRange(ranges: ReadonlyArray<{0: any, 1: any}>, options?: { includeLowers?: boolean, includeUppers?: boolean }): Collection<T, TKey>;
   startsWith(key: string): Collection<T, TKey>;
@@ -21,6 +21,6 @@ export interface WhereClause<T=any, TKey=IndexableType> {
   startsWithIgnoreCase(key: string): Collection<T, TKey>;
   startsWithAnyOfIgnoreCase(prefixes: string[]): Collection<T, TKey>;
   startsWithAnyOfIgnoreCase(...prefixes: string[]): Collection<T, TKey>;
-  noneOf(keys: ReadonlyArray<IndexableType | TKey>): Collection<T, TKey>;
-  notEqual(key: IndexableType | TKey): Collection<T, TKey>;
+  noneOf(keys: ReadonlyArray<IndexableType>): Collection<T, TKey>;
+  notEqual(key: IndexableType): Collection<T, TKey>;
 }

--- a/test/typings-test/test-typings.ts
+++ b/test/typings-test/test-typings.ts
@@ -76,15 +76,22 @@ import './test-extend-dexie';
         prop1: Date;
     }
 
+    interface CompoundKeyEntity {
+        firstName: string;
+        lastName: string;
+    }
+
     class MyDatabase extends Dexie {
         friends: Dexie.Table<Friend, number>;
         table2: Dexie.Table<Entity2, string>;
+        compoundTable: Dexie.Table<CompoundKeyEntity, [string, string]>;
 
         constructor () {
             super ('MyDatabase');
             this.version(1).stores({
                 table1: '++id',
-                table2: 'oid'
+                table2: 'oid',
+                compoundTable: '[firstName+lastName]'
             });
         }
     }
@@ -112,6 +119,12 @@ import './test-extend-dexie';
 
     // Table.where
     db.friends.where('name').equalsIgnoreCase('kalle').count(count => count.toExponential());
+    // Table.where with compound key
+    db.compoundTable.where('[firstName+lastName]').anyOf([['Kalle', 'Smith'], ['Fred', 'Smith']]);
+    db.compoundTable.where('[firstName+lastName]').anyOf(['Kalle', 'Smith'], ['Fred', 'Smith']);
+    db.compoundTable.where('[firstName+lastName]').noneOf([['Kalle', 'Smith'], ['Fred', 'Smith']]);
+    db.compoundTable.where('[firstName+lastName]').equals(['Kalle', 'Smith'])
+    db.compoundTable.where('[firstName+lastName]').notEqual(['Kalle', 'Smith'])
     // Table.filter
     db.friends.filter(friend => /kalle/.test(friend.name)).count();
     // Table.count


### PR DESCRIPTION
This fixes a syntax error when trying to call `WhereClause.anyOf()` with a compound key in TypeScript