### PR TITLE
Fix #862: Invalid JSON in Filtered Chunked Exports

### DIFF
--- a/addons/dexie-export-import/package-lock.json
+++ b/addons/dexie-export-import/package-lock.json
@@ -973,7 +973,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -994,12 +995,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1014,17 +1017,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1141,7 +1147,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1153,6 +1160,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1167,6 +1175,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1174,12 +1183,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1198,6 +1209,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1278,7 +1290,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1290,6 +1303,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1375,7 +1389,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1411,6 +1426,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1430,6 +1446,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1473,12 +1490,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/addons/dexie-export-import/src/export.ts
+++ b/addons/dexie-export-import/src/export.ts
@@ -112,6 +112,7 @@ export async function exportDB(db: Dexie, options?: ExportOptions): Promise<Blob
       const posEndRowsArray = emptyTableExportJson.lastIndexOf(']');
       slices.push(emptyTableExportJson.substring(0, posEndRowsArray));
       let lastKey: any = null;
+      let lastNumRows = 0;
       let mayHaveMoreRows = true;
       while (mayHaveMoreRows) {
         if (progressCallback) {
@@ -126,7 +127,7 @@ export async function exportDB(db: Dexie, options?: ExportOptions): Promise<Blob
 
         if (values.length === 0) break;
 
-        if (lastKey != null) {
+        if (lastKey != null && lastNumRows > 0) {
           // Not initial chunk. Must add a comma:
           slices.push(",");
           if (prettyJson) {
@@ -152,6 +153,7 @@ export async function exportDB(db: Dexie, options?: ExportOptions): Promise<Blob
           // By generating a blob here, we give web platform the opportunity to store the contents
           // on disk and release RAM.
           slices.push(new Blob([json.substring(1, json.length - 1)]));
+          lastNumRows = filteredValues.length;
           lastKey = values.length > 0 ?
             Dexie.getByKeyPath(values[values.length -1], primKey.keyPath as string) :
             null;
@@ -171,6 +173,7 @@ export async function exportDB(db: Dexie, options?: ExportOptions): Promise<Blob
           // By generating a blob here, we give web platform the opportunity to store the contents
           // on disk and release RAM.
           slices.push(new Blob([json.substring(1, json.length - 1)]));
+          lastNumRows = keyvals.length;
           lastKey = keys.length > 0 ?
             keys[keys.length - 1] :
             null;

--- a/addons/dexie-export-import/test/edge-cases.ts
+++ b/addons/dexie-export-import/test/edge-cases.ts
@@ -38,7 +38,7 @@ promisedTest("chunkedExport (issue #854)", async ()=>{
   equal (rejson2, rejson3, "Second and third expots are equal");
 });
 
-promisedTest("filtered-chunkedExport (issue #854)", async ()=>{
+promisedTest("filtered-chunkedExport (issue #862)", async ()=>{
   const blob = new Blob([JSON.stringify(IMPORT_DATA)]);
   await Dexie.delete(DATABASE_NAME);
   const db = await Dexie.import(blob);

--- a/addons/dexie-export-import/test/edge-cases.ts
+++ b/addons/dexie-export-import/test/edge-cases.ts
@@ -37,3 +37,32 @@ promisedTest("chunkedExport (issue #854)", async ()=>{
   equal (rejson1, rejson2, "First and second exports are equal");
   equal (rejson2, rejson3, "Second and third expots are equal");
 });
+
+promisedTest("filtered-chunkedExport (issue #854)", async ()=>{
+  const blob = new Blob([JSON.stringify(IMPORT_DATA)]);
+  await Dexie.delete(DATABASE_NAME);
+  const db = await Dexie.import(blob);
+  const exportBlob1 = await db.export({numRowsPerChunk: 1000, filter: () => false});
+  ok(true, "Could export using numRowsPerChunk: 1000");
+  const exportBlob2 = await db.export({numRowsPerChunk: 1, filter: () => false});
+  ok(true, "Could export using numRowsPerChunk: 1");
+  const exportBlob3 = await db.export({numRowsPerChunk: 1, prettyJson: true, filter: () => false});
+  ok(true, "Could export using numRowsPerChunk: 1 and prettyJson: true");
+  const json1 = await readBlob(exportBlob1);
+  ok(true, "Could read back first blob: " + json1);
+  const json2 = await readBlob(exportBlob2);
+  ok(true, "Could read back second blob: " + json2);
+  const json3 = await readBlob(exportBlob3);
+  ok(true, "Could read back third blob: " + json3);
+  const parsed1 = JSON.parse(json1);
+  ok(true, "Could parse first export");
+  const parsed2 = JSON.parse(json2);
+  ok(true, "Could parse second export");
+  const parsed3 = JSON.parse(json3);
+  ok(true, "Could parse third export");
+  const rejson1 = JSON.stringify(parsed1);
+  const rejson2 = JSON.stringify(parsed2);
+  const rejson3 = JSON.stringify(parsed3);
+  equal (rejson1, rejson2, "First and second exports are equal");
+  equal (rejson2, rejson3, "Second and third expots are equal");
+});


### PR DESCRIPTION
- Added unit test for filtered chunked exports (#862)
- Fixed #862:
  - exportAll@dexie/addons/dexie-export-impot/src/export.ts:
    - Code now tracks the number of filtered rows
    - Commas are now appended to table data only when the number of filtered rows in the last iteration is greater than 0
- All tests passing