### PR TITLE
Fix #872

### DIFF
--- a/addons/dexie-export-import/src/import.ts
+++ b/addons/dexie-export-import/src/import.ts
@@ -105,7 +105,7 @@ export async function importInto(db: Dexie, exportedData: Blob | JsonStream<Dexi
           throw new Error(`Primary key differs for table ${tableExport.tableName}. `);
         }
 
-        const sourceRows = tableExport.rows.map(row => row);
+        const sourceRows = tableExport.rows
         
         // Our rows may be partial, so we need to ensure each one is completed before using it
         const rows: any[] = [];
@@ -140,7 +140,7 @@ export async function importInto(db: Dexie, exportedData: Blob | JsonStream<Dexi
         if (!(rows as any).incomplete) {
           progress.completedTables += 1;
         }
-        tableExport.rows.splice(0, rows.length); // Free up RAM, keep existing array instance.
+        sourceRows.splice(0, rows.length); // Free up RAM, keep existing array instance.
       }
 
       // Avoid unnescessary loops in "for (const tableExport of dbExport.data)" 


### PR DESCRIPTION
As mentioned in #872, importing large databases had a massive memory overhead, leading to browser crashes.

The reason for this is that the parser couldn't parse objects partially, it had to finish parsing the entire object before making it available to the importer. This caused each import to potentially hold mutliple copies of the entire database in memory.

Changes:
- json-stream now makes partially-processed objects available
  - on creation, objects are given a property: `obj.incomplete = true`
  - when the object is finished being parsed, the `obj.incomplete` property is removed
- import functions fully respect the aforementioned changes

All unit tests pass.