### PR TITLE
Expose transaction in populate event

### DIFF
--- a/src/public/types/db-events.d.ts
+++ b/src/public/types/db-events.d.ts
@@ -1,5 +1,6 @@
 import { DexieEventSet } from "./dexie-event-set";
 import { DexieEvent } from "./dexie-event";
+import { Transaction } from "./transaction";
 
 export interface DexieOnReadyEvent {
   subscribe(fn: () => any, bSticky: boolean): void;
@@ -13,13 +14,19 @@ export interface DexieVersionChangeEvent {
   fire(event: IDBVersionChangeEvent): any;
 }
 
+export interface DexiePopulateEvent {
+  subscribe(fn: (trans: Transaction) => any): void;
+  unsubscribe(fn: (trans: Transaction) => any): void;
+  fire(trans: Transaction): any;
+}
+
 export interface DbEvents extends DexieEventSet {
   (eventName: 'ready', subscriber: () => any, bSticky?: boolean): void;
-  (eventName: 'populate', subscriber: () => any): void;
+  (eventName: 'populate', subscriber: (trans: Transaction) => any): void;
   (eventName: 'blocked', subscriber: (event: IDBVersionChangeEvent) => any): void;
   (eventName: 'versionchange', subscriber: (event: IDBVersionChangeEvent) => any): void;
   ready: DexieOnReadyEvent;
-  populate: DexieEvent;
+  populate: DexiePopulateEvent;
   blocked: DexieEvent;
   versionchange: DexieVersionChangeEvent;        
 }


### PR DESCRIPTION
(to accurately match what is provided runtime)
populate event is run when database is within an upgrade transaction for the inital creation of the schema.
Since Dexie has its own zone system, this given transaction argument does not need to be used, but we've also used the convention to provide the transaction instance to upgraders and this change matches that as populate is a special type of upgrader.