### PR TITLE
Resolves #722

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "dexie": [
       "# Build dist/dexie.js, dist/dexie.mjs and dist/dexie.d.ts",
       "cd src",
-      "tsc [--watch 'Compilation complete.']",
+      "tsc [--watch 'Watching for file changes']",
       "rollup -c ../tools/build-configs/rollup.config.js",
       "node ../tools/replaceVersionAndDate.js ../dist/dexie.js",
       "node ../tools/replaceVersionAndDate.js ../dist/dexie.mjs",
@@ -77,7 +77,7 @@
     "test": [
       "# Build the test suite.",
       "cd test",
-      "tsc [--watch 'Compilation complete.']",
+      "tsc [--watch 'Watching for file changes']",
       "rollup -c ../tools/build-configs/rollup.tests.config.js"
     ]
   },

--- a/src/helpers/promise.d.ts
+++ b/src/helpers/promise.d.ts
@@ -22,7 +22,6 @@ export interface DexiePromiseConstructor extends PromiseExtendedConstructor {
 }
 
 export const NativePromise : PromiseConstructor;
-export const AsyncFunction : FunctionConstructor;
 export var globalPSD;
 export var PSD;
 export function wrap<F extends Function>(f: F, errorCatcher?: (err) => void) : F;

--- a/test/run-unit-tests.html
+++ b/test/run-unit-tests.html
@@ -9,8 +9,9 @@
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
     <script src="babel-polyfill/polyfill.min.js"></script>
-    <!-- <script src="../node_modules/promise-polyfill/promise.js"></script> -->
+    <!-- <script src="https://unpkg.com/zone.js/dist/zone.js"></script> -->
     <script src="../node_modules/regenerator-runtime/runtime.js"></script>
+    <!-- <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script> -->
     <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
     <script src="../dist/dexie.js"></script>
     <!-- <script> if (typeof Promise === 'undefined') Promise = Dexie.Promise </script> -->


### PR DESCRIPTION
Could find the native promise using crypto.subtle.digest instead.

Also: Not anymore relying on wether the callback to db.transaction() or .upgrade() is an async function or not. Always being prepared for async/await in any transaction instead.

Also: Taking hight for larger number of micro-awaits than before.