### PR TITLE
Correct type definitions for syncable addon

### DIFF
--- a/addons/Dexie.Syncable/src/Dexie.Syncable.d.ts
+++ b/addons/Dexie.Syncable/src/Dexie.Syncable.d.ts
@@ -22,13 +22,13 @@ declare module 'dexie' {
              * Stop syncing with given url.. See docs at:
              * https://github.com/dfahlander/Dexie.js/wiki/db.syncable.disconnect()
              */
-            disconnect(url: string): void;
+            disconnect(url: string): Dexie.Promise<void>;
 
             /**
              * Stop syncing and delete all sync state for given URL. See docs at:
              * https://github.com/dfahlander/Dexie.js/wiki/db.syncable.delete()
              */
-            delete(url: string): void;
+            delete(url: string): Dexie.Promise<void>;
 
             /**
              * List remote URLs. See docs at:


### PR DESCRIPTION
@oppianmatt and @tunarob from my team found a mistake in type definitions of Dexie.Syncable addon: `disconnect` and `delete` are missing Promise return type. 