### PR TITLE
Upgraded clarinet

### DIFF
--- a/addons/dexie-export-import/package-lock.json
+++ b/addons/dexie-export-import/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-export-import",
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -415,9 +415,9 @@
       }
     },
     "clarinet": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.1.tgz",
-      "integrity": "sha1-Pi4mEsJXPRcrGxcbkvLc7RXJilo=",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.4.tgz",
+      "integrity": "sha512-Rx9Zw8KQkoPO3/O2yPRchCZm3cGubCQiRLmmFAlbkDKobUIPP3JYul+bKILR9DIv1gSVwPQSgF8JGGkXzX8Q0w==",
       "dev": true
     },
     "class-utils": {

--- a/addons/dexie-export-import/package.json
+++ b/addons/dexie-export-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-export-import",
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "description": "Dexie addon that adds export and import capabilities",
   "main": "dist/dexie-export-import.js",
   "module": "dist/dexie-export-import.mjs",
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "base64-arraybuffer-es6": "*",
-    "clarinet": "^0.12.1",
+    "clarinet": "^0.12.4",
     "just-build": "^0.9.16",
     "karma": "^4.1.0",
     "karma-browserstack-launcher": "^1.5.1",


### PR DESCRIPTION
This PR affects dexie-export-import only.
Upgrade the bundled dependency clarinet to the version that includes my PR.
Bump version number. 
This version is already released on npm.
