### PR TITLE
Fix for issue 947

### DIFF
--- a/src/classes/collection/collection.ts
+++ b/src/classes/collection/collection.ts
@@ -496,7 +496,7 @@ export class Collection implements ICollection {
       const applyMutateResult = (expectedCount: number, res: MutateResponse) => {
         const {failures, numFailures} = res;
         successCount += expectedCount - numFailures;
-        for (let pos in failures) {
+        for (let pos of keys(failures)) {
           totalFailures.push(failures[pos]);
         }
       }


### PR DESCRIPTION
Iterate the failures array using for...of Object.keys() instead of for..in.
