### PR TITLE
Import IDatabaseChange directly in Dexie.Syncable vs re-exporting from api

### DIFF
--- a/addons/Dexie.Syncable/api.d.ts
+++ b/addons/Dexie.Syncable/api.d.ts
@@ -17,19 +17,18 @@
  *
  * By separating module 'dexie-syncable' from 'dexie-syncable/api' we
  * distinguish that:
- * 
+ *
  *   import {...} from 'dexie-syncable/api' is only for getting access to its
  *                                          interfaces and has no side-effects.
  *                                          Typescript-only import.
- * 
+ *
  *   import 'dexie-syncable' is only for side effects - to extend Dexie with
  *                           functionality of dexie-syncable.
  *                           Javascript / Typescript import.
- * 
+ *
  */
 
 import {IDatabaseChange} from 'dexie-observable/api';
-export type IDatabaseChange = IDatabaseChange;
 export {DatabaseChangeType} from 'dexie-observable/api';
 
 /* ISyncProtocol
@@ -48,9 +47,9 @@ export {DatabaseChangeType} from 'dexie-observable/api';
 
 /**
  * The interface to implement to provide sync towards a remote server.
- * 
+ *
  * Documentation for this interface: https://github.com/dfahlander/Dexie.js/wiki/Dexie.Syncable.ISyncProtocol
- * 
+ *
  */
 export interface ISyncProtocol {
     partialsThreshold?: number;
@@ -108,7 +107,7 @@ export interface ReactiveContinuation {
 
         /** If true, it means that reach() will be called upon again with additional changes once you'version
          * called onChangesAccepted(). An implementation may handle this transactionally, i.e. wait with applying
-         * these changes and instead buffer them in a temporary table and the apply everything once reac() is called 
+         * these changes and instead buffer them in a temporary table and the apply everything once reac() is called
          * with partial=false.
          */
         partial: boolean,

--- a/addons/Dexie.Syncable/src/Dexie.Syncable.d.ts
+++ b/addons/Dexie.Syncable/src/Dexie.Syncable.d.ts
@@ -4,7 +4,8 @@
 
 import Dexie from 'dexie';
 import 'dexie-observable';
-import { IDatabaseChange, ISyncProtocol, SyncStatus } from '../api';
+import { ISyncProtocol, SyncStatus } from '../api';
+import {IDatabaseChange} from 'dexie-observable/api';
 
 //
 // Extend Dexie interface
@@ -17,7 +18,7 @@ declare module 'dexie' {
              * https://github.com/dfahlander/Dexie.js/wiki/db.syncable.connect()
              */
             connect(protocol: string, url: string, options?: any): Dexie.Promise<void>;
-            
+
             /**
              * Stop syncing with given url.. See docs at:
              * https://github.com/dfahlander/Dexie.js/wiki/db.syncable.disconnect()
@@ -52,7 +53,7 @@ declare module 'dexie' {
         /**
          * Table used for storing uncommitted changes when downloading partial change sets from
          * a sync server.
-         * 
+         *
          * Each change is bound to a node id (represents the remote server that the change was
          * downloaded from)
          */
@@ -65,8 +66,8 @@ declare module 'dexie' {
         // allow storing remote nodes in table _syncNodes.
         module Observable {
             interface SyncNode {
-                url: string, // Only applicable for "remote" nodes. Only used in Dexie.Syncable.                
-                syncProtocol: string, // Tells which implementation of ISyncProtocol to use for remote syncing. 
+                url: string, // Only applicable for "remote" nodes. Only used in Dexie.Syncable.
+                syncProtocol: string, // Tells which implementation of ISyncProtocol to use for remote syncing.
                 syncContext: any,
                 syncOptions: any,
                 status: number,
@@ -77,7 +78,7 @@ declare module 'dexie' {
                     currentTable: string,
                     currentKey: any,
                     localBaseRevision: number
-                }                
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #944. Note that the [npm page](https://www.npmjs.com/package/dexie-syncable) contains the following snippet:

```
import Dexie from 'dexie';
import 'dexie-syncable'; // will import dexie-observable as well.
```

I am unclear on whether consumers need access to IDatabaseChange, but if so, dexie-observable will also need to be imported.