### PR TITLE
typeson/typeson-registry update

### DIFF
--- a/addons/dexie-export-import/package-lock.json
+++ b/addons/dexie-export-import/package-lock.json
@@ -33,9 +33,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -693,9 +693,9 @@
       "dev": true
     },
     "es6-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
     "es6-promisify": {
@@ -1634,12 +1634,12 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
@@ -1653,9 +1653,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -3243,21 +3243,28 @@
       "dev": true
     },
     "typeson": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typeson/-/typeson-5.8.2.tgz",
-      "integrity": "sha512-AFuyvVdHdkGlVIalOrSFjylmeLeWFtKu77uDjEilP4B9+Jk0DCM1m1A4Q2s3AwROhgiFFVPI8oARaD9S61lOkg==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/typeson/-/typeson-5.18.1.tgz",
+      "integrity": "sha512-4cVDwf4tT+9hpeQk22/ioQJXL8lN3AYlzJfJLBpB0MDPG7CGpbvxR0HBkQ6qp9T72/yzryP6k2HSVdxd3jF5qg==",
       "dev": true
     },
     "typeson-registry": {
-      "version": "1.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.21.tgz",
-      "integrity": "sha512-D7aj2KAzOaLvzCAYNhoFW536uWwbmSz5gSaO5fWETERLFheCOEIiMifGI4GDyGatxRvUJMz0ydp/ZEYYzs9iwQ==",
+      "version": "1.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.33.tgz",
+      "integrity": "sha512-q0jMkVizN10rzPtPcwkUC+pAOlA4iq4tl/GJ0iHDuMCnK3HxaN26bR/SczedswPBt0Pd+c0GjXZDDK+Cn2pgwg==",
       "dev": true,
       "requires": {
-        "base64-arraybuffer-es6": "0.3.1",
-        "typeson": "5.8.2",
-        "uuid": "3.2.1",
-        "whatwg-url": "6.4.0"
+        "base64-arraybuffer-es6": "0.5.0",
+        "typeson": "5.18.1",
+        "whatwg-url": "7.1.0"
+      },
+      "dependencies": {
+        "base64-arraybuffer-es6": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.5.0.tgz",
+          "integrity": "sha512-UCIPaDJrNNj5jG2ZL+nzJ7czvZV/ZYX6LaIRgfVU1k1edJOQg7dkbiSKzwHkNp6aHEHER/PhlFBrMYnlvJJQEw==",
+          "dev": true
+        }
       }
     },
     "ultron": {
@@ -3379,12 +3386,6 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
-    "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-      "dev": true
-    },
     "void-elements": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
@@ -3398,14 +3399,14 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.0",
-        "webidl-conversions": "^4.0.1"
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "which": {

--- a/addons/dexie-export-import/package.json
+++ b/addons/dexie-export-import/package.json
@@ -47,8 +47,8 @@
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^3.4.0",
     "typescript": "^3.1.3",
-    "typeson": "^5.8.2",
-    "typeson-registry": "^1.0.0-alpha.21"
+    "typeson": "^5.18.1",
+    "typeson-registry": "^1.0.0-alpha.33"
   },
   "dependencies": {
     "dexie": "^3.0.0-alpha.5 || ^2.0.4"

--- a/addons/dexie-export-import/src/tson.ts
+++ b/addons/dexie-export-import/src/tson.ts
@@ -1,82 +1,10 @@
 import Typeson from 'typeson';
 import StructuredCloning from 'typeson-registry/dist/presets/structured-cloning';
-import { encode as encodeB64, decode as decodeB64 } from 'base64-arraybuffer-es6';
-import Dexie from 'dexie';
-import { readBlobSync, readBlobAsync } from './helpers';
 import typedArray from './tson-typed-array';
 import arrayBuffer from './tson-arraybuffer';
 
-export const TSON = new Typeson().register(StructuredCloning);
-
-const readBlobsSynchronously = 'FileReaderSync' in self; // true in workers only.
-
-let blobsToAwait: any[] = [];
-let blobsToAwaitPos = 0;
-
-// Need to patch encapsulateAsync as it does not work as of typeson 5.8.2
-// Also, current version of typespn-registry-1.0.0-alpha.21 does not
-// encapsulate/revive Blobs correctly (fails one of the unit tests in
-// this library (test 'export-format'))
-TSON.register([
+export const TSON = new Typeson().register([
+  StructuredCloning,
   arrayBuffer,
-  typedArray, {
-    blob2: {
-      test(x) { return Typeson.toStringTag(x) === 'Blob'; },
-      replace(b) {
-          if (b.isClosed) { // On MDN, but not in https://w3c.github.io/FileAPI/#dfn-Blob
-            throw new Error('The Blob is closed');
-          }
-          if (readBlobsSynchronously) {
-            const data = readBlobSync(b, 'binary');
-            const base64 = encodeB64(data, 0, data.byteLength);
-            return {
-              type: b.type,
-              data: base64
-            }
-          } else {
-            blobsToAwait.push(b); // This will also make TSON.mustFinalize() return true.
-            const result = {
-              type: b.type,
-              data: {start: blobsToAwaitPos, end: blobsToAwaitPos + b.size}
-            }
-            console.log("b.size: " + b.size);
-            blobsToAwaitPos += b.size;
-            return result;
-          }
-      },
-      finalize(b, ba: ArrayBuffer) {
-        b.data = encodeB64(ba, 0, ba.byteLength);
-      },
-      revive ({type, data}) {
-        return new Blob([decodeB64(data)], {type});
-      }
-    }
-  }
+  typedArray
 ]);
-
-TSON.mustFinalize = ()=>blobsToAwait.length > 0;
-
-TSON.finalize = async (items?: any[]) => {
-  const allChunks = await readBlobAsync(new Blob(blobsToAwait), 'binary');
-  if (items) {
-    for (const item of items) {
-      // Manually go through all "blob" types in the result
-      // and lookup the data slice they point at.
-      if (item.$types) {
-        let types = item.$types;
-        const arrayType = types.$;
-        if (arrayType) types = types.$;
-        for (let keyPath in types) {
-          const typeName = types[keyPath];
-          const typeSpec = TSON.types[typeName];
-          if (typeSpec && typeSpec.finalize) {
-            const b = Dexie.getByKeyPath(item, arrayType ? "$." + keyPath : keyPath);
-            typeSpec.finalize(b, allChunks.slice(b.start, b.end));
-          }
-        }
-      }
-    }
-  }
-  // Free up memory
-  blobsToAwait = [];
-}


### PR DESCRIPTION
- Refactoring: With typeson/tyepson-registry update, can avoid `finalize` patching
- npm: Update typeson/typeson-registry

If you like, I can also tack on to this PR:

1. Updating the other devDeps
2. Remove your internal use of `arraybuffer` as it is already present with the typeson-registry structured cloning preset, and with basically the same implementation but relying on the defaulting of `base64-arraybuffer-es6` and caching existent buffers for the sake of cyclical references.
3. Replace your internal use of `tson-typed-array` with `typeson-registry`'s `typed-arrays`. (While the `typed-arrays-socketio` type works with your code as it is if you prefer, the `socketio` preset does not (despite `socketio` now passing `typeson-registry` tests); I haven't looked closely enough at your code to see which makes more sense.)

(By the way, we don't have the preservation of `byteOffset` and `length` in `typeson-registry`'s `typed-arrays-socketio` type as we do with the `typed-arrays` type. While we could preserve it, since we are just passing on the buffer as is unless the type is detected as `ArrayBuffer`, I guess maybe it doesn't fit there.)

If this is too much info to review now, feel free to just review the PR as is.