### PR TITLE
fix the compiler warnings & stuff

### DIFF
--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -55,7 +55,7 @@ var override = Dexie.override;
 var Promise = Dexie.Promise;
 var browserIsShuttingDown = false;
 
-export default function Observable(db) {
+export default function Observable(db: Dexie) {
     /// <summary>
     ///   Extension to Dexie providing Syncronization capabilities to Dexie.
     /// </summary>

--- a/src/classes/collection/collection-helpers.ts
+++ b/src/classes/collection/collection-helpers.ts
@@ -1,11 +1,9 @@
 import { combine } from "../../functions/combine";
 import { exceptions } from "../../errors";
-import { hasOwn, trycatcher } from "../../functions/utils";
+import { hasOwn } from "../../functions/utils";
 import { wrap } from "../../helpers/promise";
-import { eventRejectHandler } from "../../functions/event-wrappers";
 import { Collection } from './';
-import { DBCoreCursor, DBCoreTable, DBCoreTransaction, DBCoreTableSchema, RangeType } from '../../public/types/dbcore';
-import { Table } from '../table';
+import { DBCoreCursor, DBCoreTable, DBCoreTransaction, DBCoreTableSchema } from '../../public/types/dbcore';
 import { nop } from '../../functions/chaining-functions';
 
 type CollectionContext = Collection["_ctx"];
@@ -13,7 +11,7 @@ type CollectionContext = Collection["_ctx"];
 export function isPlainKeyRange (ctx: CollectionContext, ignoreLimitFilter?: boolean) {
   return !(ctx.filter || ctx.algorithm || ctx.or) &&
       (ignoreLimitFilter ? ctx.justLimit : !ctx.replayFilter);
-}    
+}
 
 export function addFilter(ctx: CollectionContext, fn: Function) {
   ctx.filter = combine(ctx.filter, fn);
@@ -46,14 +44,14 @@ export function openCursor(ctx: CollectionContext, coreTable: DBCoreTable, trans
     reverse: ctx.dir === 'prev',
     unique: !!ctx.unique,
     query: {
-      index, 
+      index,
       range: ctx.range
     }
   });
 }
 
 export function iter (
-  ctx: CollectionContext, 
+  ctx: CollectionContext,
   fn: (item, cursor: DBCoreCursor, advance: Function)=>void,
   coreTrans: DBCoreTransaction,
   coreTable: DBCoreTable): Promise<any>
@@ -86,12 +84,12 @@ export function iter (
 }
 
 function iterate(cursorPromise: Promise<DBCoreCursor>, filter, fn, valueMapper): Promise<any> {
-  
+
   // Apply valueMapper (hook('reading') or mappped class)
   var mappedFn = valueMapper ? (x,c,a) => fn(valueMapper(x),c,a) : fn;
   // Wrap fn with PSD and microtick stuff from Promise.
   var wrappedFn = wrap(mappedFn);
-  
+
   return cursorPromise.then(cursor => {
     if (cursor) {
       return cursor.start(()=>{

--- a/src/classes/dexie/dexie-static-props.ts
+++ b/src/classes/dexie/dexie-static-props.ts
@@ -2,24 +2,22 @@ import { Dexie as _Dexie } from './dexie';
 import { props, derive, extend, override, getByKeyPath, setByKeyPath, delByKeyPath, shallowClone, deepClone, getObjectDiff, asap, _global } from '../../functions/utils';
 import { fullNameExceptions } from '../../errors';
 import { DexieConstructor } from '../../public/types/dexie-constructor';
-import { DatabaseEnumerator, databaseEnumerator } from '../../helpers/database-enumerator';
+import { databaseEnumerator } from '../../helpers/database-enumerator';
 import { PSD } from '../../helpers/promise';
 import { usePSD } from '../../helpers/promise';
-import { newScope } from '../../helpers/promise';
 import { rejection } from '../../helpers/promise';
 import { awaitIterator } from '../../helpers/yield-support';
 import Promise from '../../helpers/promise';
 import * as Debug from '../../helpers/debug';
 import { dexieStackFrameFilter, minKey, connections, DEXIE_VERSION } from '../../globals/constants';
 import Events from '../../helpers/Events';
-import { exceptions } from '../../errors';
 import { errnames } from '../../errors';
 import { getMaxKey } from '../../functions/quirks';
 import { vip } from './vip';
 
 /* (Dexie) is an instance of DexieConstructor, as defined in public/types/dexie-constructor.d.ts
 *  (new Dexie()) is an instance of Dexie, as defined in public/types/dexie.d.ts
-* 
+*
 * Why we're doing this?
 
 * Because we've choosen to define the public Dexie API using a DexieConstructor interface
@@ -32,7 +30,7 @@ const Dexie = _Dexie as any as DexieConstructor;
 
 //
 // Set all static methods and properties onto Dexie:
-// 
+//
 props(Dexie, {
 
   // Dexie.BulkError = class BulkError {...};
@@ -138,7 +136,7 @@ props(Dexie, {
       typeof promiseOrFunction === 'function' ?
         Dexie.ignoreTransaction(promiseOrFunction) :
         promiseOrFunction)
-      .timeout(optionalTimeout || 60000); // Default the timeout to one minute. Caller may specify Infinity if required.       
+      .timeout(optionalTimeout || 60000); // Default the timeout to one minute. Caller may specify Infinity if required.
 
     // Run given promise on current transaction. If no current transaction, just return a Dexie promise based
     // on given value.

--- a/src/classes/dexie/dexie.ts
+++ b/src/classes/dexie/dexie.ts
@@ -9,8 +9,7 @@ import { DbSchema } from '../../public/types/db-schema';
 
 // Internal imports
 import { Table, TableConstructor, createTableConstructor } from "../table";
-import { Collection, CollectionConstructor, createCollectionConstructor } from '../collection';
-import { WhereClause } from '../where-clause/where-clause';
+import { CollectionConstructor, createCollectionConstructor } from '../collection';
 import { WhereClauseConstructor, createWhereClauseConstructor } from '../where-clause/where-clause-constructor';
 import { Transaction } from '../transaction';
 import { TransactionConstructor, createTransactionConstructor } from '../transaction/transaction-constructor';
@@ -18,14 +17,12 @@ import { Version } from "../version/version";
 import { VersionConstructor, createVersionConstructor } from '../version/version-constructor';
 
 // Other imports...
-import { DexieEventSet } from '../../public/types/dexie-event-set';
-import { DexieExceptionClasses } from '../../public/types/errors';
 import { DexieDOMDependencies } from '../../public/types/dexie-dom-dependencies';
 import { nop, promisableChain } from '../../functions/chaining-functions';
 import Promise, { PSD } from '../../helpers/promise';
-import { extend, override, keys, hasOwn } from '../../functions/utils';
+import { override, keys, hasOwn } from '../../functions/utils';
 import Events from '../../helpers/Events';
-import { maxString, connections, READONLY, READWRITE } from '../../globals/constants';
+import { connections, READONLY, READWRITE } from '../../globals/constants';
 import { getMaxKey } from '../../functions/quirks';
 import { exceptions } from '../../errors';
 import { lowerVersionFirst } from '../version/schema-helpers';
@@ -132,7 +129,7 @@ export class Dexie implements IDexie {
           if (state.openComplete) {
             // Database already open. Call subscriber asap.
             if (!state.dbOpenError) Promise.resolve().then(subscriber);
-            // bSticky: Also subscribe to future open sucesses (after close / reopen) 
+            // bSticky: Also subscribe to future open sucesses (after close / reopen)
             if (bSticky) subscribe(subscriber);
           } else if (state.onReadyBeingFired) {
             // db.on('ready') subscribers are currently being executed and have not yet resolved or rejected
@@ -257,7 +254,7 @@ export class Dexie implements IDexie {
     if (stack && this._middlewares[stack]) {
       this._middlewares[stack] = this._middlewares[stack].filter(mw =>
         create ? mw.create !== create : // Given middleware has a create method. Match that exactly.
-        name ? mw.name !== name : // Given middleware spec 
+        name ? mw.name !== name : // Given middleware spec
         false);
     }
     return this;
@@ -377,7 +374,7 @@ export class Dexie implements IDexie {
             if (parentTransaction.mode === READONLY && idbMode === READWRITE) {
                 if (onlyIfCompatible) {
                     // Spawn new transaction instead.
-                    parentTransaction = null; 
+                    parentTransaction = null;
                 }
                 else throw new exceptions.SubTransaction("Cannot enter a sub-transaction with READWRITE mode when parent transaction is READONLY");
             }
@@ -386,7 +383,7 @@ export class Dexie implements IDexie {
                     if (parentTransaction && parentTransaction.storeNames.indexOf(storeName) === -1) {
                         if (onlyIfCompatible) {
                             // Spawn new transaction instead.
-                            parentTransaction = null; 
+                            parentTransaction = null;
                         }
                         else throw new exceptions.SubTransaction("Table " + storeName +
                             " not included in parent transaction.");

--- a/src/classes/dexie/generate-middleware-stacks.ts
+++ b/src/classes/dexie/generate-middleware-stacks.ts
@@ -3,13 +3,12 @@ import { createDBCore } from '../../dbcore/dbcore-indexeddb';
 import { DBCore } from '../../public/types/dbcore';
 import { DexieDOMDependencies } from '../../public/types/dexie-dom-dependencies';
 import { DexieStacks, Middleware } from '../../public/types/middleware';
-import { exceptions } from '../../errors';
 
 function createMiddlewareStack<TStack extends {stack: string}>(
   stackImpl: {stack: string},
   middlewares: Middleware<{stack: string}>[]): TStack {
   return middlewares.reduce((down, {create}) => ({...down, ...create(down)}), stackImpl) as TStack;
-} 
+}
 
 function createMiddlewareStacks(
   middlewares: {[StackName in keyof DexieStacks]?: Middleware<DexieStacks[StackName]>[]},
@@ -20,7 +19,7 @@ function createMiddlewareStacks(
   const dbcore = createMiddlewareStack<DBCore>(
     createDBCore(idbdb, indexedDB, IDBKeyRange, tmpTrans),
     middlewares.dbcore);
-  
+
   // TODO: Create other stacks the same way as above. They might be dependant on the result
   // of creating dbcore stack.
 

--- a/src/classes/transaction/transaction.ts
+++ b/src/classes/transaction/transaction.ts
@@ -8,13 +8,12 @@ import { exceptions } from '../../errors';
 import { safariMultiStoreFix } from '../../functions/quirks';
 import { preventDefault } from '../../functions/event-wrappers';
 import { newScope } from '../../helpers/promise';
-import * as Debug from '../../helpers/debug';
 import { Table } from '../table';
 
 /** Transaction
- * 
+ *
  * http://dexie.org/docs/Transaction/Transaction
- * 
+ *
  **/
 export class Transaction implements ITransaction {
   db: Dexie;
@@ -41,7 +40,7 @@ export class Transaction implements ITransaction {
   //
 
   /** Transaction._lock()
-   * 
+   *
    * Internal method.
    */
   _lock() {
@@ -53,7 +52,7 @@ export class Transaction implements ITransaction {
   }
 
   /** Transaction._unlock()
-   * 
+   *
    * Internal method.
    */
   _unlock() {
@@ -69,7 +68,7 @@ export class Transaction implements ITransaction {
   }
 
   /** Transaction._lock()
-   * 
+   *
    * Internal method.
    */
   _locked() {
@@ -87,9 +86,9 @@ export class Transaction implements ITransaction {
   }
 
   /** Transaction.create()
-   * 
+   *
    * Internal method.
-   * 
+   *
    */
   create(idbtrans?: IDBTransaction) {
     if (!this.mode) return this;
@@ -131,7 +130,7 @@ export class Transaction implements ITransaction {
   }
 
   /** Transaction._promise()
-   * 
+   *
    * Internal method.
    */
   _promise(
@@ -175,7 +174,7 @@ export class Transaction implements ITransaction {
   }
 
   /** Transaction._root()
-   * 
+   *
    * Internal method. Retrieves the root transaction in the tree of sub transactions.
    */
   _root() {
@@ -183,10 +182,10 @@ export class Transaction implements ITransaction {
   }
 
   /** Transaction.waitFor()
-   * 
+   *
    * Internal method. Can be accessed from the public API through
    * Dexie.waitFor(): http://dexie.org/docs/Dexie/Dexie.waitFor()
-   * 
+   *
    **/
   waitFor(promiseLike: PromiseLike<any>) {
     // Always operate on the root transaction (in case this is a sub stransaction)
@@ -221,10 +220,10 @@ export class Transaction implements ITransaction {
         }
       });
     });
-  }  
+  }
 
   /** Transaction.abort()
-   * 
+   *
    * http://dexie.org/docs/Transaction/Transaction.abort()
    */
   abort() {
@@ -233,7 +232,7 @@ export class Transaction implements ITransaction {
   }
 
   /** Transaction.table()
-   * 
+   *
    * http://dexie.org/docs/Transaction/Transaction.table()
    */
   table(tableName: string) {
@@ -242,7 +241,7 @@ export class Transaction implements ITransaction {
       return memoizedTables[tableName];
     const tableSchema = this.schema[tableName];
     if (!tableSchema) {
-      throw new exceptions.NotFound("Table " + tableName + " not part of transaction");        
+      throw new exceptions.NotFound("Table " + tableName + " not part of transaction");
     }
 
     const transactionBoundTable = new this.db.Table(tableName, tableSchema, this);

--- a/src/classes/version/schema-helpers.ts
+++ b/src/classes/version/schema-helpers.ts
@@ -8,7 +8,6 @@ import { exceptions } from '../../errors';
 import { TableSchema } from '../../public/types/table-schema';
 import { IndexSpec } from '../../public/types/index-spec';
 import { hasIEDeleteObjectStoreBug } from '../../globals/constants';
-import { safariMultiStoreFix } from '../../functions/quirks';
 import { createIndexSpec, nameFromKeyPath } from '../../helpers/index-spec';
 import { createTableSchema } from '../../helpers/table-schema';
 import { generateMiddlewareStacks } from '../dexie/generate-middleware-stacks';
@@ -94,7 +93,7 @@ export function updateTablesAndIndexes(
       globalSchema = db._dbSchema = newSchema;
 
       const diff = getSchemaDiff(oldSchema, newSchema);
-      // Add tables           
+      // Add tables
       diff.add.forEach(tuple => {
         createTable(idbUpgradeTrans, tuple[0], tuple[1].primKey, tuple[1].indexes);
       });
@@ -140,7 +139,7 @@ export function updateTablesAndIndexes(
 
         // Support for native async await.
         incrementExpectedAwaits();
-        
+
         let returnValue: any;
         const promiseFollowed = Promise.follow(() => {
           // Finally, call the scope function with our table and transaction arguments.

--- a/src/classes/where-clause/where-clause-helpers.ts
+++ b/src/classes/where-clause/where-clause-helpers.ts
@@ -1,9 +1,7 @@
 import { WhereClause } from './where-clause';
 import { Collection } from '../collection';
-import { Dexie } from '../dexie';
 import { STRING_EXPECTED } from '../../globals/constants';
 import { simpleCompare, simpleCompareReverse } from '../../functions/compare-functions';
-import { CollectionConstructor } from '../collection';
 import { IndexableType } from '../../public';
 import { KeyRange, RangeType } from '../../public/types/dbcore';
 
@@ -11,7 +9,7 @@ export function fail(collectionOrWhereClause: Collection | WhereClause, err, T?)
   var collection = collectionOrWhereClause instanceof WhereClause ?
       new collectionOrWhereClause.Collection (collectionOrWhereClause) :
       collectionOrWhereClause;
-      
+
   collection._ctx.error = T ? new T(err) : new TypeError(err);
   return collection;
 }
@@ -50,8 +48,7 @@ export function nextCasing(key, lowerKey, upperNeedle, lowerNeedle, cmp, dir) {
   return (llp < 0 ? null : key.substr(0, llp) + lowerNeedle[llp] + upperNeedle.substr(llp + 1));
 }
 
-export function addIgnoreCaseAlgorithm(whereClause: WhereClause, match, needles, suffix) {
-  /// <param name="needles" type="Array" elementType="String"></param>
+export function addIgnoreCaseAlgorithm(whereClause: WhereClause, match, needles: [String], suffix) {
   var upper, lower, compare, upperNeedles, lowerNeedles, direction, nextKeySuffix,
       needlesLen = needles.length;
   if (!needles.every(s => typeof s === 'string')) {
@@ -66,8 +63,8 @@ export function addIgnoreCaseAlgorithm(whereClause: WhereClause, match, needles,
       }).sort(function(a,b) {
           return compare(a.lower, b.lower);
       });
-      upperNeedles = needleBounds.map(function (nb){ return nb.upper; });
-      lowerNeedles = needleBounds.map(function (nb){ return nb.lower; });
+      upperNeedles = needleBounds.map(nb => nb.upper);
+      lowerNeedles = needleBounds.map(nb => nb.lower);
       direction = dir;
       nextKeySuffix = (dir === "next" ? "" : suffix);
   }
@@ -85,10 +82,7 @@ export function addIgnoreCaseAlgorithm(whereClause: WhereClause, match, needles,
 
   var firstPossibleNeedle = 0;
 
-  c._addAlgorithm(function (cursor, advance, resolve) {
-      /// <param name="cursor" type="IDBCursor"></param>
-      /// <param name="advance" type="Function"></param>
-      /// <param name="resolve" type="Function"></param>
+  c._addAlgorithm(function (cursor: IDBCursor, advance: Function, resolve: Function) {
       var key = cursor.key;
       if (typeof key !== 'string') return false;
       var lowerKey = lower(key);

--- a/src/classes/where-clause/where-clause.ts
+++ b/src/classes/where-clause/where-clause.ts
@@ -1,17 +1,16 @@
 import { WhereClause as IWhereClause } from "../../public/types/where-clause";
 import { Collection } from "../collection";
 import { Table } from "../table";
-import { IndexableTypeArray, IndexableType } from "../../public/types/indexable-type";
+import { IndexableType } from "../../public/types/indexable-type";
 import { emptyCollection, fail, addIgnoreCaseAlgorithm, createRange, rangeEqual } from './where-clause-helpers';
 import { INVALID_KEY_ARGUMENT, STRING_EXPECTED, maxString, minKey } from '../../globals/constants';
 import { getArrayOf, NO_CHAR_ARRAY } from '../../functions/utils';
 import { exceptions } from '../../errors';
 import { Dexie } from '../dexie';
 import { Collection as ICollection} from "../../public/types/collection";
-import { RangeType } from '../../public/types/dbcore';
 
 /** class WhereClause
- * 
+ *
  * http://dexie.org/docs/WhereClause/WhereClause
  */
 export class WhereClause implements IWhereClause {
@@ -33,9 +32,9 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.between()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.between()
-   * 
+   *
    **/
   between(lower: IndexableType, upper: IndexableType, includeLower?: boolean, includeUpper?: boolean) {
     includeLower = includeLower !== false;   // Default to true
@@ -51,18 +50,18 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.equals()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.equals()
-   * 
+   *
    **/
   equals(value: IndexableType) {
     return new this.Collection(this, () => rangeEqual(value)) as ICollection;
   }
 
   /** WhereClause.above()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.above()
-   * 
+   *
    **/
   above(value: IndexableType) {
     if (value == null) return fail(this, INVALID_KEY_ARGUMENT);
@@ -70,9 +69,9 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.aboveOrEqual()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.aboveOrEqual()
-   * 
+   *
    **/
   aboveOrEqual(value: IndexableType) {
     if (value == null) return fail(this, INVALID_KEY_ARGUMENT);
@@ -80,9 +79,9 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.below()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.below()
-   * 
+   *
    **/
   below(value: IndexableType) {
     if (value == null) return fail(this, INVALID_KEY_ARGUMENT);
@@ -90,9 +89,9 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.belowOrEqual()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.belowOrEqual()
-   * 
+   *
    **/
   belowOrEqual(value: IndexableType) {
     if (value == null) return fail(this, INVALID_KEY_ARGUMENT);
@@ -100,9 +99,9 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.startsWith()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.startsWith()
-   * 
+   *
    **/
   startsWith(str: string) {
     if (typeof str !== 'string') return fail(this, STRING_EXPECTED);
@@ -110,9 +109,9 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.startsWithIgnoreCase()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.startsWithIgnoreCase()
-   * 
+   *
    **/
   startsWithIgnoreCase(str: string) {
     if (str === "") return this.startsWith(str);
@@ -120,18 +119,18 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.equalsIgnoreCase()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.equalsIgnoreCase()
-   * 
+   *
    **/
   equalsIgnoreCase(str: string) {
     return addIgnoreCaseAlgorithm(this, (x, a) => x === a[0], [str], "");
   }
 
   /** WhereClause.anyOfIgnoreCase()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.anyOfIgnoreCase()
-   * 
+   *
    **/
   anyOfIgnoreCase(...values: string[]): Collection;
   anyOfIgnoreCase(values: string[]): Collection;
@@ -142,9 +141,9 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.startsWithAnyOfIgnoreCase()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.startsWithAnyOfIgnoreCase()
-   * 
+   *
    **/
   startsWithAnyOfIgnoreCase(...values: string[]): Collection;
   startsWithAnyOfIgnoreCase(values: string[]): Collection;
@@ -155,9 +154,9 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.anyOf()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.anyOf()
-   * 
+   *
    **/
   anyOf(...values: string[]): Collection;
   anyOf(values: string[]): Collection;
@@ -200,18 +199,18 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.notEqual()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.notEqual()
-   * 
+   *
    **/
   notEqual(value: IndexableType) {
     return this.inAnyRange([[minKey, value], [value, this.db._maxKey]], { includeLowers: false, includeUppers: false });
   }
 
   /** WhereClause.noneOf()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.noneOf()
-   * 
+   *
    **/
   noneOf(...values: string[]): Collection;
   noneOf(values: string[]): Collection;
@@ -230,9 +229,9 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.inAnyRange()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.inAnyRange()
-   * 
+   *
    **/
   inAnyRange(
     ranges: ReadonlyArray<{ 0: IndexableType, 1: IndexableType }>,
@@ -345,9 +344,9 @@ export class WhereClause implements IWhereClause {
   }
 
   /** WhereClause.startsWithAnyOf()
-   * 
+   *
    * http://dexie.org/docs/WhereClause/WhereClause.startsWithAnyOf()
-   * 
+   *
    **/
   startsWithAnyOf(...prefixes: string[]): Collection;
   startsWithAnyOf(prefixes: string[]): Collection;

--- a/src/dbcore/get-key-extractor.ts
+++ b/src/dbcore/get-key-extractor.ts
@@ -1,5 +1,4 @@
-import { exceptions } from '../errors';
-import { isArray, getByKeyPath } from '../functions/utils';
+import { getByKeyPath } from '../functions/utils';
 import { Key } from '../public/types/dbcore';
 
 export function getKeyExtractor (keyPath: null | string | string[]) : (a: any) => Key {

--- a/src/dbcore/keyrange.ts
+++ b/src/dbcore/keyrange.ts
@@ -1,7 +1,5 @@
 import { KeyRange, RangeType } from '../public/types/dbcore';
 
-var x: KeyRange;
-
 export const AnyRange: KeyRange = {
   type: RangeType.Any,
   lower: -Infinity,

--- a/src/functions/compare-functions.ts
+++ b/src/functions/compare-functions.ts
@@ -1,4 +1,3 @@
-import { IndexableType } from '../public/types/indexable-type';
 
 export function simpleCompare(a, b) {
   return a < b ? -1 : a === b ? 0 : 1;

--- a/src/functions/make-class-constructor.ts
+++ b/src/functions/make-class-constructor.ts
@@ -1,4 +1,4 @@
-import { arrayToObject, derive } from './utils';
+import { derive } from './utils';
 
 
 export function makeClassConstructor<TConstructor> (prototype: Object, constructor: Function) {
@@ -19,5 +19,5 @@ export function makeClassConstructor<TConstructor> (prototype: Object, construct
   // The code below will only create a prototypal inheritance from given constructor function
   // to given prototype.
   derive(constructor).from({prototype});
-  return constructor as any as TConstructor;  
+  return constructor as any as TConstructor;
 }

--- a/src/functions/temp-transaction.ts
+++ b/src/functions/temp-transaction.ts
@@ -1,5 +1,4 @@
 import { PSD, rejection, newScope } from "../helpers/promise";
-import { DexieOptions } from "../public/types/dexie-constructor";
 import { exceptions } from "../errors";
 import { nop } from "./chaining-functions";
 import { Transaction } from "../classes/transaction";

--- a/src/helpers/table-schema.ts
+++ b/src/helpers/table-schema.ts
@@ -1,6 +1,5 @@
 import { IndexSpec } from '../public/types/index-spec';
 import { TableSchema } from '../public/types/table-schema';
-import { createIndexSpec } from './index-spec';
 import { arrayToObject } from '../functions/utils';
 
 export function createTableSchema (

--- a/src/hooks/hooks-middleware.ts
+++ b/src/hooks/hooks-middleware.ts
@@ -1,6 +1,6 @@
 import { DBCore, DBCoreTable, MutateResponse, DeleteRangeRequest, AddRequest, PutRequest, DeleteRequest, DBCoreTransaction, KeyRange } from '../public/types/dbcore';
 import { nop } from '../functions/chaining-functions';
-import { tryCatch, getObjectDiff, setByKeyPath } from '../functions/utils';
+import { getObjectDiff, setByKeyPath } from '../functions/utils';
 import { PSD } from '../helpers/promise';
 //import { LockableTableMiddleware } from '../dbcore/lockable-table-middleware';
 import { getEffectiveKeys, getExistingValues } from '../dbcore/get-effective-keys';
@@ -16,7 +16,7 @@ export const hooksMiddleware: Middleware<DBCore>  = {
     table(tableName: string) {
       const downTable = downCore.table(tableName);
       const {primaryKey} = downTable.schema;
-  
+
       const tableMiddleware: DBCoreTable = {
         ...downTable,
         mutate(req):Promise<MutateResponse> {
@@ -52,7 +52,7 @@ export const hooksMiddleware: Middleware<DBCore>  = {
               {...req};
             if (req.type !== 'delete') req.values = [...req.values];
             if (req.keys) req.keys = [...req.keys];
-  
+
             return getExistingValues(downTable, req, keys).then (existingValues => {
               const contexts = keys.map((key, i) => {
                 const existingValue = existingValues[i];
@@ -104,11 +104,11 @@ export const hooksMiddleware: Middleware<DBCore>  = {
               });
             });
           }
-  
+
           function deleteRange(req: DeleteRangeRequest): Promise<MutateResponse> {
             return deleteNextChunk(req.trans, req.range, 10000);
           }
-  
+
           function deleteNextChunk(trans: DBCoreTransaction, range: KeyRange, limit: number) {
             // Query what keys in the DB within the given range
             return downTable.query({trans, values: false, query: {index: primaryKey, range}, limit})


### PR DESCRIPTION
I started out attempting to make an es6 version of dexie that does not have all of the backwards compatible browser stuff in it. my target platform is chrome/electron, and considering the new IE is based on chromium now. I also want to have a version have a version that is also lighter as well (right now dexie is 60KB+ minimised) so I can include only the parts that I need.

anyway, this is my first time using typescript, and honestly it's quite nice :) results that the compiler spits out some warnings and there are tons of unused variables and imports which my editor complains about as well. I fixed all of them. unfortunately, my editor also deletes trailing whitespace. I noticed in your latest commit, trailing whitespace was also trimmed so I feel less bad about it.

just in case you want it, this seems to be most of the major fixes.

---

in addition, I was wondering if it's possible to (on chrome/electron) use the native unpatched promises? do you know of any major things that can go wrong if I change dexie use those? (the reason why I say is because you have added things like long stack trace support, which chrome supports natively and other things.) that'll probably be the next thing I try