### PR TITLE
Feature:  optionally all keys are returned on creating methods

### DIFF
--- a/src/public/types/table.d.ts
+++ b/src/public/types/table.d.ts
@@ -47,7 +47,14 @@ export interface Table<T=any, TKey=IndexableType> {
   delete(key: TKey): PromiseExtended<void>;
   clear(): PromiseExtended<void>;
   bulkGet(keys: TKey[]): PromiseExtended<T[]>;
-  bulkAdd(items: T[], keys?: IndexableTypeArrayReadonly): PromiseExtended<TKey>;
-  bulkPut(items: T[], keys?: IndexableTypeArrayReadonly): PromiseExtended<TKey>;
-  bulkDelete(keys: IndexableTypeArrayReadonly) : PromiseExtended<void>;
+
+  bulkAdd<B extends boolean>(items: T[], keys: IndexableTypeArrayReadonly, options: { allKeys: B }): B extends true ? Promise<TKey[]> : Promise<TKey>;
+  bulkAdd<B extends boolean>(items: T[], options: { allKeys: B }): B extends true ? Promise<TKey[]> : Promise<TKey>;
+  bulkAdd(items: T[], keys?: IndexableTypeArrayReadonly, options?: { allKeys: boolean }): Promise<TKey>;
+
+  bulkPut<B extends boolean>(items: T[], keys: IndexableTypeArrayReadonly, options: { allKeys: B }): B extends true ? Promise<TKey[]> : Promise<TKey>;
+  bulkPut<B extends boolean>(items: T[], options: { allKeys: B }): B extends true ? Promise<TKey[]> : Promise<TKey>;
+  bulkPut(items: T[], keys?: IndexableTypeArrayReadonly, options?: { allKeys: boolean }): Promise<TKey>;
+
+  bulkDelete(keys: IndexableTypeArrayReadonly): PromiseExtended<void>;
 }


### PR DESCRIPTION
See Issue: #969 

**Added code to support an options object on bulkAdd() and bulkPut() methods.**

These methods now accept an optional object on the second or third parameter. Instead of receiving only the last key it is now possible to use the, already implemented feature, to return all keys via { allKeys: true }:

_Example:_
`bulkAdd(someObject[], { allKeys: true })`
or
`bulkAdd(someObject[], someKey[], { allKeys: true })`

**Typings**
Also included improved typings for these methods. Via overloads, the correct return type (TKey | TKey[]) will be used.

**Tests**
Added test for the updated methods and some tests for backward compatibility (**no breaking changes**).

**Performance**
Did not add any performance tests (didn't know how and where you wanted them). I did some testing in my own app. Could not find any meaningful / significant differences. So seems ok.

**Documentation**
Not updated because different repo.