### PR TITLE
Revert to Dexie 2.0 behavior regarding native await handling to poten…

### DIFF
--- a/src/classes/dexie/transaction-helpers.ts
+++ b/src/classes/dexie/transaction-helpers.ts
@@ -53,8 +53,8 @@ export function enterTransactionScope(
     }
 
     // Support for native async await.
-    const asyncScopeFunc = isAsyncFunction(scopeFunc);
-    if (asyncScopeFunc) {
+    const scopeFuncIsAsync = isAsyncFunction(scopeFunc);
+    if (scopeFuncIsAsync) {
       incrementExpectedAwaits();
     }
 
@@ -63,7 +63,7 @@ export function enterTransactionScope(
       // Finally, call the scope function with our table and transaction arguments.
       returnValue = scopeFunc.call(trans, trans);
       if (returnValue) {
-        if (asyncScopeFunc) {
+        if (scopeFuncIsAsync) {
           // scopeFunc is a native async function - we know for sure returnValue is native promise.
           var decrementor = decrementExpectedAwaits.bind(null, null);
           returnValue.then(decrementor, decrementor);

--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -313,3 +313,6 @@ export function getArrayOf (arrayLike) {
     while (i--) a[i] = arguments[i];
     return a;
 }
+export const isAsyncFunction = typeof Symbol !== 'undefined'
+    ? (fn: Function) => fn[Symbol.toStringTag] === 'AsyncFunction'
+    : ()=>false;


### PR DESCRIPTION
…tially resolve #928.

In PR #915 did begin to always be prepared for native await calls in the scopeFunc of db.transaction(). So that it should work also if given scopeFunc was not declared async itself, but was forwarding the call to a real async function.

This commit will revert that particular part of the #928 PR. Still we are CSP compliant and all else fixed in #915, but we revert to requiring the callback function in Dexie.transaction() and Verison.upgrade() to be declared async in order to keep Dexie.currentTransaction correct between await calls.

The reason for this is mainly to stick to the proven behavior of Dexie 2.x and not introduce different behaviors in Dexie 3.0 that could potentially trigger bugs in various environments such as Firefox 68 on Android, as could be the issue in #928.
