### PR TITLE
fix: add missing properties on observable change

### DIFF
--- a/addons/Dexie.Observable/api.d.ts
+++ b/addons/Dexie.Observable/api.d.ts
@@ -32,7 +32,7 @@ export interface IUpdateChange {
     type: DatabaseChangeType.Update;
     table: string;
     key: any;
-    mods: { [keyPath: string]: any | undefined };
+    mods: {[keyPath: string]: any | undefined};
     obj: any;
     oldObj: any;
 }

--- a/addons/Dexie.Observable/api.d.ts
+++ b/addons/Dexie.Observable/api.d.ts
@@ -16,32 +16,32 @@
  *
  */
 export const enum DatabaseChangeType {
-  Create = 1,
-  Update = 2,
-  Delete = 3,
+    Create = 1,
+    Update = 2,
+    Delete = 3,
 }
 
 export interface ICreateChange {
-  type: DatabaseChangeType.Create;
-  table: string;
-  key: any;
-  obj: any;
+    type: DatabaseChangeType.Create;
+    table: string;
+    key: any;
+    obj: any;
 }
 
 export interface IUpdateChange {
-  type: DatabaseChangeType.Update;
-  table: string;
-  key: any;
-  mods: { [keyPath: string]: any | undefined };
-  obj: any;
-  oldObj: any;
+    type: DatabaseChangeType.Update;
+    table: string;
+    key: any;
+    mods: { [keyPath: string]: any | undefined };
+    obj: any;
+    oldObj: any;
 }
 
 export interface IDeleteChange {
-  type: DatabaseChangeType.Delete;
-  table: string;
-  key: any;
-  oldObj: any;
+    type: DatabaseChangeType.Delete;
+    table: string;
+    key: any;
+    oldObj: any;
 }
 
 export type IDatabaseChange = ICreateChange | IUpdateChange | IDeleteChange;

--- a/addons/Dexie.Observable/api.d.ts
+++ b/addons/Dexie.Observable/api.d.ts
@@ -1,44 +1,47 @@
 /**
  * API for Dexie.Observable.
- * 
+ *
  * Contains interfaces used by dexie-observable.
- * 
+ *
  * By separating module 'dexie-observable' from 'dexie-observable/api' we
  * distinguish that:
- * 
+ *
  *   import {...} from 'dexie-observable/api' is only for getting access to its
  *                                            interfaces and has no side-effects.
  *                                            Typescript-only import.
- * 
+ *
  *   import 'dexie-observable' is only for side effects - to extend Dexie with
  *                             functionality of dexie-observable.
  *                             Javascript / Typescript import.
- * 
+ *
  */
 export const enum DatabaseChangeType {
-    Create = 1,
-    Update = 2,
-    Delete = 3
+  Create = 1,
+  Update = 2,
+  Delete = 3,
 }
 
 export interface ICreateChange {
-    type: DatabaseChangeType.Create,
-    table: string;
-    key: any;
-    obj: any;
+  type: DatabaseChangeType.Create;
+  table: string;
+  key: any;
+  obj: any;
 }
 
 export interface IUpdateChange {
-    type: DatabaseChangeType.Update;
-    table: string;
-    key: any;
-    mods: {[keyPath: string]:any | undefined};
+  type: DatabaseChangeType.Update;
+  table: string;
+  key: any;
+  mods: { [keyPath: string]: any | undefined };
+  obj: any;
+  oldObj: any;
 }
 
 export interface IDeleteChange {
-    type: DatabaseChangeType.Delete;
-    table: string;
-    key: any;
+  type: DatabaseChangeType.Delete;
+  table: string;
+  key: any;
+  oldObj: any;
 }
 
-export type IDatabaseChange = ICreateChange | IUpdateChange | IDeleteChange; 
+export type IDatabaseChange = ICreateChange | IUpdateChange | IDeleteChange;

--- a/addons/Dexie.Observable/test/typings/test-typings.ts
+++ b/addons/Dexie.Observable/test/typings/test-typings.ts
@@ -1,7 +1,7 @@
 import Dexie from 'dexie';
 import '../../src/Dexie.Observable';
 import dexieObservable from '../../src/Dexie.Observable';
-import { IDatabaseChange, DatabaseChangeType } from '../../api';
+import {IDatabaseChange, DatabaseChangeType} from '../../api';
 
 interface Foo {
     id: string;
@@ -11,8 +11,8 @@ class MyDb extends Dexie {
     foos: Dexie.Table<Foo, string>;
 
     constructor() {
-        super('testdb', { addons: [dexieObservable, Dexie.Observable] });
-        this.version(1).stores({ foos: '$$id' });
+        super('testdb', {addons: [dexieObservable, Dexie.Observable]});
+        this.version(1).stores({foos: '$$id'});
     }
 }
 
@@ -32,10 +32,10 @@ db.on('message', (msg) => {
     msg.resolve('foo');
     msg.reject(new Error('Foo'));
 });
-db.observable.sendMessage('myMsgType', { foo: 'bar' }, 13, { wantReply: true });
-db.observable.sendMessage('myMsgType', 'foobar', 13, { wantReply: false });
+db.observable.sendMessage('myMsgType', {foo: 'bar'}, 13, {wantReply: true});
+db.observable.sendMessage('myMsgType', 'foobar', 13, {wantReply: false});
 
-db.observable.broadcastMessage('myBroadcastMsgType', { foo2: 'bar2' }, false);
+db.observable.broadcastMessage('myBroadcastMsgType', {foo2: 'bar2'}, false);
 
 db.on('changes', (changes) => {
     changes.forEach((change) => {

--- a/addons/Dexie.Observable/test/typings/test-typings.ts
+++ b/addons/Dexie.Observable/test/typings/test-typings.ts
@@ -1,20 +1,19 @@
-
 import Dexie from 'dexie';
 import '../../src/Dexie.Observable';
 import dexieObservable from '../../src/Dexie.Observable';
 import { IDatabaseChange, DatabaseChangeType } from '../../api';
 
 interface Foo {
-    id: string;
+  id: string;
 }
 
 class MyDb extends Dexie {
-    foos: Dexie.Table<Foo, string>;
+  foos: Dexie.Table<Foo, string>;
 
-    constructor() {
-        super('testdb', {addons: [dexieObservable, Dexie.Observable]});
-        this.version(1).stores({foos: '$$id'});
-    }
+  constructor() {
+    super('testdb', { addons: [dexieObservable, Dexie.Observable] });
+    this.version(1).stores({ foos: '$$id' });
+  }
 }
 
 let db = new MyDb();
@@ -25,51 +24,65 @@ syncNode.deleteTimeStamp.toExponential();
 syncNode.lastHeartBeat.toExponential();
 syncNode.myRevision.toFixed();
 
-db.on('message', msg => {
-    msg.type;
-    msg.message;
-    msg.destinationNode * 1;
-    msg.wantReply;
-    msg.resolve('foo');
-    msg.reject(new Error('Foo'));
+db.on('message', (msg) => {
+  msg.type;
+  msg.message;
+  msg.destinationNode * 1;
+  msg.wantReply;
+  msg.resolve('foo');
+  msg.reject(new Error('Foo'));
 });
-db.observable.sendMessage('myMsgType', {foo: 'bar'}, 13, {wantReply: true});
-db.observable.sendMessage('myMsgType', 'foobar', 13, {wantReply: false});
+db.observable.sendMessage('myMsgType', { foo: 'bar' }, 13, { wantReply: true });
+db.observable.sendMessage('myMsgType', 'foobar', 13, { wantReply: false });
 
-db.observable.broadcastMessage('myBroadcastMsgType', {foo2: 'bar2'}, false);
+db.observable.broadcastMessage('myBroadcastMsgType', { foo2: 'bar2' }, false);
 
-db.on('changes', changes => {
-    changes.forEach(change => {
-        switch (change.type) {
-            case DatabaseChangeType.Create:
-                change.table.toLowerCase();
-                change.key;
-                change.obj;                
-                break;
-            case DatabaseChangeType.Update:
-                change.table.toLowerCase();
-                change.key;
-                change.mods;
-                break;
-            case DatabaseChangeType.Delete:
-                change.table.toLowerCase();
-                change.key;
-                break;
-        }
-    })
+db.on('changes', (changes) => {
+  changes.forEach((change) => {
+    switch (change.type) {
+      case DatabaseChangeType.Create:
+        change.table.toLowerCase();
+        change.key;
+        change.obj;
+        break;
+      case DatabaseChangeType.Update:
+        change.table.toLowerCase();
+        change.key;
+        change.mods;
+        break;
+      case DatabaseChangeType.Delete:
+        change.table.toLowerCase();
+        change.key;
+        break;
+    }
+  });
 });
 
 Dexie.Observable.createUUID().toLowerCase();
-Dexie.Observable.on('latestRevisionIncremented', (dbName, rev) => {dbName.toLowerCase(); rev.toFixed()});
-Dexie.Observable.on('latestRevisionIncremented').subscribe(()=>{});
-Dexie.Observable.on('latestRevisionIncremented').fire(()=>{});
-Dexie.Observable.on('latestRevisionIncremented').unsubscribe(()=>{});
+Dexie.Observable.on('latestRevisionIncremented', (dbName, rev) => {
+  dbName.toLowerCase();
+  rev.toFixed();
+});
+Dexie.Observable.on('latestRevisionIncremented').subscribe(() => {});
+Dexie.Observable.on('latestRevisionIncremented').fire(() => {});
+Dexie.Observable.on('latestRevisionIncremented').unsubscribe(() => {});
 
-Dexie.Observable.on('suicideNurseCall', (dbName, nodeId)=>{dbName.toLowerCase(); nodeId.toExponential()});
-Dexie.Observable.on('intercomm', dbName=>{dbName.toLowerCase()});
-Dexie.Observable.on('beforeunload', ()=>{});
+Dexie.Observable.on('suicideNurseCall', (dbName, nodeId) => {
+  dbName.toLowerCase();
+  nodeId.toExponential();
+});
+Dexie.Observable.on('intercomm', (dbName) => {
+  dbName.toLowerCase();
+});
+Dexie.Observable.on('beforeunload', () => {});
 
-Dexie.Observable.on('latestRevisionIncremented').unsubscribe(()=>{});
-var x: IDatabaseChange = {key: 1, table: "", type: DatabaseChangeType.Delete};
+Dexie.Observable.on('latestRevisionIncremented').unsubscribe(() => {});
+var x: IDatabaseChange = {
+  key: 1,
+  table: '',
+  type: DatabaseChangeType.Delete,
+  oldObj: {},
+};
 x.key;
 x.type;
+x.oldObj;

--- a/addons/Dexie.Observable/test/typings/test-typings.ts
+++ b/addons/Dexie.Observable/test/typings/test-typings.ts
@@ -1,7 +1,7 @@
-import Dexie from "dexie";
-import "../../src/Dexie.Observable";
-import dexieObservable from "../../src/Dexie.Observable";
-import { IDatabaseChange, DatabaseChangeType } from "../../api";
+import Dexie from 'dexie';
+import '../../src/Dexie.Observable';
+import dexieObservable from '../../src/Dexie.Observable';
+import { IDatabaseChange, DatabaseChangeType } from '../../api';
 
 interface Foo {
     id: string;
@@ -11,8 +11,8 @@ class MyDb extends Dexie {
     foos: Dexie.Table<Foo, string>;
 
     constructor() {
-        super("testdb", { addons: [dexieObservable, Dexie.Observable] });
-        this.version(1).stores({ foos: "$$id" });
+        super('testdb', { addons: [dexieObservable, Dexie.Observable] });
+        this.version(1).stores({ foos: '$$id' });
     }
 }
 
@@ -24,20 +24,20 @@ syncNode.deleteTimeStamp.toExponential();
 syncNode.lastHeartBeat.toExponential();
 syncNode.myRevision.toFixed();
 
-db.on("message", (msg) => {
+db.on('message', (msg) => {
     msg.type;
     msg.message;
     msg.destinationNode * 1;
     msg.wantReply;
-    msg.resolve("foo");
-    msg.reject(new Error("Foo"));
+    msg.resolve('foo');
+    msg.reject(new Error('Foo'));
 });
-db.observable.sendMessage("myMsgType", { foo: "bar" }, 13, { wantReply: true });
-db.observable.sendMessage("myMsgType", "foobar", 13, { wantReply: false });
+db.observable.sendMessage('myMsgType', { foo: 'bar' }, 13, { wantReply: true });
+db.observable.sendMessage('myMsgType', 'foobar', 13, { wantReply: false });
 
-db.observable.broadcastMessage("myBroadcastMsgType", { foo2: "bar2" }, false);
+db.observable.broadcastMessage('myBroadcastMsgType', { foo2: 'bar2' }, false);
 
-db.on("changes", (changes) => {
+db.on('changes', (changes) => {
     changes.forEach((change) => {
         switch (change.type) {
             case DatabaseChangeType.Create:
@@ -59,27 +59,27 @@ db.on("changes", (changes) => {
 });
 
 Dexie.Observable.createUUID().toLowerCase();
-Dexie.Observable.on("latestRevisionIncremented", (dbName, rev) => {
+Dexie.Observable.on('latestRevisionIncremented', (dbName, rev) => {
     dbName.toLowerCase();
     rev.toFixed();
 });
-Dexie.Observable.on("latestRevisionIncremented").subscribe(() => {});
-Dexie.Observable.on("latestRevisionIncremented").fire(() => {});
-Dexie.Observable.on("latestRevisionIncremented").unsubscribe(() => {});
+Dexie.Observable.on('latestRevisionIncremented').subscribe(() => {});
+Dexie.Observable.on('latestRevisionIncremented').fire(() => {});
+Dexie.Observable.on('latestRevisionIncremented').unsubscribe(() => {});
 
-Dexie.Observable.on("suicideNurseCall", (dbName, nodeId) => {
+Dexie.Observable.on('suicideNurseCall', (dbName, nodeId) => {
     dbName.toLowerCase();
     nodeId.toExponential();
 });
-Dexie.Observable.on("intercomm", (dbName) => {
+Dexie.Observable.on('intercomm', (dbName) => {
     dbName.toLowerCase();
 });
-Dexie.Observable.on("beforeunload", () => {});
+Dexie.Observable.on('beforeunload', () => {});
 
-Dexie.Observable.on("latestRevisionIncremented").unsubscribe(() => {});
+Dexie.Observable.on('latestRevisionIncremented').unsubscribe(() => {});
 var x: IDatabaseChange = {
     key: 1,
-    table: "",
+    table: '',
     type: DatabaseChangeType.Delete,
     oldObj: {},
 };

--- a/addons/Dexie.Observable/test/typings/test-typings.ts
+++ b/addons/Dexie.Observable/test/typings/test-typings.ts
@@ -1,19 +1,19 @@
-import Dexie from 'dexie';
-import '../../src/Dexie.Observable';
-import dexieObservable from '../../src/Dexie.Observable';
-import { IDatabaseChange, DatabaseChangeType } from '../../api';
+import Dexie from "dexie";
+import "../../src/Dexie.Observable";
+import dexieObservable from "../../src/Dexie.Observable";
+import { IDatabaseChange, DatabaseChangeType } from "../../api";
 
 interface Foo {
-  id: string;
+    id: string;
 }
 
 class MyDb extends Dexie {
-  foos: Dexie.Table<Foo, string>;
+    foos: Dexie.Table<Foo, string>;
 
-  constructor() {
-    super('testdb', { addons: [dexieObservable, Dexie.Observable] });
-    this.version(1).stores({ foos: '$$id' });
-  }
+    constructor() {
+        super("testdb", { addons: [dexieObservable, Dexie.Observable] });
+        this.version(1).stores({ foos: "$$id" });
+    }
 }
 
 let db = new MyDb();
@@ -24,64 +24,64 @@ syncNode.deleteTimeStamp.toExponential();
 syncNode.lastHeartBeat.toExponential();
 syncNode.myRevision.toFixed();
 
-db.on('message', (msg) => {
-  msg.type;
-  msg.message;
-  msg.destinationNode * 1;
-  msg.wantReply;
-  msg.resolve('foo');
-  msg.reject(new Error('Foo'));
+db.on("message", (msg) => {
+    msg.type;
+    msg.message;
+    msg.destinationNode * 1;
+    msg.wantReply;
+    msg.resolve("foo");
+    msg.reject(new Error("Foo"));
 });
-db.observable.sendMessage('myMsgType', { foo: 'bar' }, 13, { wantReply: true });
-db.observable.sendMessage('myMsgType', 'foobar', 13, { wantReply: false });
+db.observable.sendMessage("myMsgType", { foo: "bar" }, 13, { wantReply: true });
+db.observable.sendMessage("myMsgType", "foobar", 13, { wantReply: false });
 
-db.observable.broadcastMessage('myBroadcastMsgType', { foo2: 'bar2' }, false);
+db.observable.broadcastMessage("myBroadcastMsgType", { foo2: "bar2" }, false);
 
-db.on('changes', (changes) => {
-  changes.forEach((change) => {
-    switch (change.type) {
-      case DatabaseChangeType.Create:
-        change.table.toLowerCase();
-        change.key;
-        change.obj;
-        break;
-      case DatabaseChangeType.Update:
-        change.table.toLowerCase();
-        change.key;
-        change.mods;
-        break;
-      case DatabaseChangeType.Delete:
-        change.table.toLowerCase();
-        change.key;
-        break;
-    }
-  });
+db.on("changes", (changes) => {
+    changes.forEach((change) => {
+        switch (change.type) {
+            case DatabaseChangeType.Create:
+                change.table.toLowerCase();
+                change.key;
+                change.obj;
+                break;
+            case DatabaseChangeType.Update:
+                change.table.toLowerCase();
+                change.key;
+                change.mods;
+                break;
+            case DatabaseChangeType.Delete:
+                change.table.toLowerCase();
+                change.key;
+                break;
+        }
+    });
 });
 
 Dexie.Observable.createUUID().toLowerCase();
-Dexie.Observable.on('latestRevisionIncremented', (dbName, rev) => {
-  dbName.toLowerCase();
-  rev.toFixed();
+Dexie.Observable.on("latestRevisionIncremented", (dbName, rev) => {
+    dbName.toLowerCase();
+    rev.toFixed();
 });
-Dexie.Observable.on('latestRevisionIncremented').subscribe(() => {});
-Dexie.Observable.on('latestRevisionIncremented').fire(() => {});
-Dexie.Observable.on('latestRevisionIncremented').unsubscribe(() => {});
+Dexie.Observable.on("latestRevisionIncremented").subscribe(() => {});
+Dexie.Observable.on("latestRevisionIncremented").fire(() => {});
+Dexie.Observable.on("latestRevisionIncremented").unsubscribe(() => {});
 
-Dexie.Observable.on('suicideNurseCall', (dbName, nodeId) => {
-  dbName.toLowerCase();
-  nodeId.toExponential();
+Dexie.Observable.on("suicideNurseCall", (dbName, nodeId) => {
+    dbName.toLowerCase();
+    nodeId.toExponential();
 });
-Dexie.Observable.on('intercomm', (dbName) => {
-  dbName.toLowerCase();
+Dexie.Observable.on("intercomm", (dbName) => {
+    dbName.toLowerCase();
 });
-Dexie.Observable.on('beforeunload', () => {});
+Dexie.Observable.on("beforeunload", () => {});
 
-Dexie.Observable.on('latestRevisionIncremented').unsubscribe(() => {});
+Dexie.Observable.on("latestRevisionIncremented").unsubscribe(() => {});
 var x: IDatabaseChange = {
-  key: 1,
-  table: '',
-  type: DatabaseChangeType.Delete,
-  oldObj: {},
+    key: 1,
+    table: "",
+    type: DatabaseChangeType.Delete,
+    oldObj: {},
 };
 x.key;
 x.type;


### PR DESCRIPTION
## Summary
Adds missing `obj` and `oldObj` properties to observable change types and update tests to pass.

## Notes
I might be missing something but it seems the interfaces are. If anything needs reworking let me know I'm happy to make the changes. 

## Related
fixes: #802