### PR TITLE
Use indexeddb.databases() and skip deprecated webkitDatabaseNames

### DIFF
--- a/src/helpers/database-enumerator.ts
+++ b/src/helpers/database-enumerator.ts
@@ -1,6 +1,4 @@
 import Promise from './promise';
-import { slice } from '../functions/utils';
-import { eventRejectHandler } from '../functions/event-wrappers';
 import { Dexie } from '../classes/dexie/dexie';
 import { Table } from '../public/types/table';
 import { nop } from '../functions/chaining-functions';


### PR DESCRIPTION
This PR will skip the use of the old, long time ago, deprecated webkitGetDatabaseNames() api and instead use the new chromium-supported indexedDB.databases() api to enumerate databases.