### PR TITLE
null check key first

### DIFF
--- a/addons/Dexie.Observable/src/on-storage.js
+++ b/addons/Dexie.Observable/src/on-storage.js
@@ -3,7 +3,7 @@ import Dexie from 'dexie';
 export default function initOnStorage(Observable) {
   return function onStorage(event) {
     // We use the onstorage event to trigger onLatestRevisionIncremented since we will wake up when other windows modify the DB as well!
-    if (event.key.indexOf("Dexie.Observable/") === 0) { // For example "Dexie.Observable/latestRevision/FriendsDB"
+    if (event.key && event.key.indexOf("Dexie.Observable/") === 0) { // For example "Dexie.Observable/latestRevision/FriendsDB"
       var parts = event.key.split('/');
       var prop = parts[1];
       var dbname = parts[2];


### PR DESCRIPTION
Dexie.Observable: Cannot read property 'indexOf' of null #791

https://github.com/dfahlander/Dexie.js/issues/791

>It is reacting to the "storage" event. When storage is cleared, it may not come with a key. A valid fix would be to null-check event.key.