### PR TITLE
Repro and fix issue 1039 - Table name "schema" not working in dexie 3

### DIFF
--- a/test/tests-table.js
+++ b/test/tests-table.js
@@ -5,7 +5,8 @@ import {resetDatabase, supports, spawnedTest, promisedTest} from './dexie-unitte
 var db = new Dexie("TestDBTable");
 db.version(1).stores({
     users: "++id,first,last,&username,*&email,*pets",
-    folks: "++,first,last"
+    folks: "++,first,last",
+    schema: "" // Test issue #1039
 });
 
 var User = db.users.defineClass({
@@ -886,4 +887,3 @@ promisedTest("bulkGet()", async () => {
     ok(u3 && u3.first === 'Foo100', "Third should be Foo100");
     ok(u4 === undefined, "Forth should be undefined");
 });
-


### PR DESCRIPTION
It's a general issue if a table name collides with a property of Transaction. This PR reproduces the issue and has a generic fix for it. All the following table names did previously trigger the issue:
* db
* mode
* storeNames
* schema
* idbtrans
* on
* parent
* active
* _reculock
* _blockedFuncs
* _resolve
* _reject
* _waitingFor
* _waitingQueue
* _spinCount
* _completion

With this fix there should no more be any restrictions on table names.