### PR TITLE
Adds missing fields to Dexie-Observable TS type definitions

### DIFF
--- a/addons/Dexie.Observable/api.d.ts
+++ b/addons/Dexie.Observable/api.d.ts
@@ -1,44 +1,50 @@
 /**
  * API for Dexie.Observable.
- * 
+ *
  * Contains interfaces used by dexie-observable.
- * 
+ *
  * By separating module 'dexie-observable' from 'dexie-observable/api' we
  * distinguish that:
- * 
+ *
  *   import {...} from 'dexie-observable/api' is only for getting access to its
  *                                            interfaces and has no side-effects.
  *                                            Typescript-only import.
- * 
+ *
  *   import 'dexie-observable' is only for side effects - to extend Dexie with
  *                             functionality of dexie-observable.
  *                             Javascript / Typescript import.
- * 
+ *
  */
 export const enum DatabaseChangeType {
     Create = 1,
     Update = 2,
-    Delete = 3
+    Delete = 3,
 }
 
 export interface ICreateChange {
-    type: DatabaseChangeType.Create,
+    type: DatabaseChangeType.Create;
     table: string;
     key: any;
     obj: any;
+    source?: string;
 }
 
 export interface IUpdateChange {
     type: DatabaseChangeType.Update;
     table: string;
     key: any;
-    mods: {[keyPath: string]:any | undefined};
+    mods: { [keyPath: string]: any | undefined };
+    obj: any;
+    oldObj: any;
+    source?: string;
 }
 
 export interface IDeleteChange {
     type: DatabaseChangeType.Delete;
     table: string;
     key: any;
+    oldObj: any;
+    source?: string;
 }
 
-export type IDatabaseChange = ICreateChange | IUpdateChange | IDeleteChange; 
+export type IDatabaseChange = ICreateChange | IUpdateChange | IDeleteChange;


### PR DESCRIPTION
This PR resolves #1057 by adding a few missing fields to the TS type definitions for the Dexie-Observable API.

The [Dexie documentat](https://dexie.org/docs/Observable/Dexie.Observable.DatabaseChange) declares that `DatabaseChange` objects should have `obj` and `oldObj` depending on the change type, as well as an optional `source` field. These fields are missing from the current Typescript definitions:
https://github.com/dfahlander/Dexie.js/blob/v3.0.1/addons/Dexie.Observable/api.d.ts