### PR TITLE
Run reading hooks on Table.bulkGet

### DIFF
--- a/src/classes/table/table.ts
+++ b/src/classes/table/table.ts
@@ -365,7 +365,7 @@ export class Table implements ITable<any, IndexableType> {
       return this.core.getMany({
         keys,
         trans
-      });
+      }).then(result => result.map(res => this.hook.reading.fire(res)));
     });
   }
 

--- a/test/tests-crud-hooks.js
+++ b/test/tests-crud-hooks.js
@@ -516,6 +516,7 @@ spawnedTest("creating using Table.bulkPut()", function*(){
 // READING hooks test
 // Ways to produce READs:
 //  Table.get()
+//  Table.bulkGet()
 //  Collection.toArray()
 //  Collection.each()
 //  Collection.first()
@@ -550,12 +551,19 @@ spawnedTest("reading tests", function* (){
     },{
         op: "read", // last()
         obj: {fee: "bore"}
+    },{
+        op: "read", // bulkGet() (1)
+        obj: {foo: "bar"}
+    },{
+        op: "read", // bulkGet() (2)
+        obj: {fee: "bore"}
     }], ()=> db.transaction('rw', 'table5', function*(){
         yield db.table5.bulkAdd([{foo: "bar"}, {fee: "bore"}], [1, 2]);
         yield db.table5.toArray();
         yield db.table5.reverse().each(x => {});
         yield db.table5.orderBy(':id').first();
         yield db.table5.orderBy(':id').last();
+        yield db.table5.bulkGet([1, 2]);
         yield db.table5.filter(x => false).toArray();
     }));
 

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -291,3 +291,29 @@ spawnedTest ("delByKeyPath not working correctly for arrays", function* () {
     console.log("jsonResult2 = ", jsonResult2);
     equal(jsonResult, jsonResult2, `Should be equal ${jsonResult} ${jsonResult2}`);
 });
+
+asyncTest ("#1079 mapToClass", function(){
+    class Foo {
+    }
+    db.foo.mapToClass(Foo);
+
+    db.transaction('rw', db.foo, function () {
+        db.foo.put({id:1});
+    }).catch(e => {
+        ok(true, `Unexpected error from put: ${e.stack || e}`);
+    }).then(() => {
+        return db.foo.get(1);
+    }).then (getResult => {
+        ok(getResult instanceof Foo, "Result of get not mapped to class");
+    }).catch(e => {
+        ok(true, `Unexpected error from get: ${e.stack || e}`);
+    }).then(() => {
+        return db.foo.bulkGet([1]);
+    }).then(bulkGetResult => {
+        ok(bulkGetResult.length === 1, `Unexpected array length ${bulkGetResult.length} from bulkGet`);
+        ok(bulkGetResult[0] instanceof Foo, "Result of bulkGet not mapped to class");
+    }).catch(e => {
+        ok(true, `Unexpected error from bulkGet: ${e.stack || e}`);
+    }).finally(start);
+
+});


### PR DESCRIPTION
Fire the reading hooks on the results of Table.bulkGet, as in Table.get.

This fixes the problem where Table.bulkGet results don't match Table.get results when Table.mapToClass is in effect. (mapToClass leverages the reading hook.)

Fixes #1079 