### PR TITLE
Fix Table.bulkGet return typing to include undefined

### DIFF
--- a/src/public/types/table.d.ts
+++ b/src/public/types/table.d.ts
@@ -46,7 +46,7 @@ export interface Table<T=any, TKey=IndexableType> {
   put(item: T, key?: TKey): PromiseExtended<TKey>;
   delete(key: TKey): PromiseExtended<void>;
   clear(): PromiseExtended<void>;
-  bulkGet(keys: TKey[]): PromiseExtended<T[]>;
+  bulkGet(keys: TKey[]): PromiseExtended<(T | undefined)[]>;
 
   bulkAdd<B extends boolean>(items: T[], keys: IndexableTypeArrayReadonly, options: { allKeys: B }): PromiseExtended<B extends true ? TKey[] : TKey>;
   bulkAdd<B extends boolean>(items: T[], options: { allKeys: B }): PromiseExtended<B extends true ? TKey[] : TKey>;

--- a/test/typings-test/test-typings.ts
+++ b/test/typings-test/test-typings.ts
@@ -145,6 +145,11 @@ import './test-extend-dexie';
     db.friends.toCollection().eachPrimaryKey(key => key.toExponential());
     // Table.orderBy
     db.friends.orderBy('name').eachPrimaryKey(key => key.toFixed());
+    // Table.bulkGet
+    db.friends.bulkGet([1, 2, 3]).then(friends => friends.map(
+        // friend => friend.address // should cause TS2532: Object is possibly 'undefined'
+        friend => friend === undefined ? "missing" : friend.address
+    ));
 
     // Hooks
     db.friends.hook('creating', function(key, friend) {


### PR DESCRIPTION
This improves the typing for Table.bulkGet() to indicate
the returned array may include undefined items.

(Per the [bulkGet docs][], "For those keys that do not
exist in the database, undefined will be returned in their
place.")

[bulkGet docs]: https://dexie.org/docs/Table/Table.bulkGet()