### PR TITLE
Verify schema on open

### DIFF
--- a/src/classes/dexie/dexie-open.ts
+++ b/src/classes/dexie/dexie-open.ts
@@ -81,13 +81,8 @@ export function dexieOpen (db: Dexie) {
             if (state.autoSchema) readGlobalSchema(db, idbdb, tmpTrans);
             else {
                 adjustToExistingIndexNames(db, db._dbSchema, tmpTrans);
-                try {
-                    verifyInstalledSchema(db, idbdb, tmpTrans, db._dbSchema);
-                } catch(e) {
-                    idbdb.close();
-                    db.idbdb = null;
-                    reject(e);
-                    return;
+                if (!verifyInstalledSchema(db, tmpTrans)) {
+                    console.warn(`Dexie SchemaDiff: Schema was extended without increasing the number passed to db.version(). Some queries may fail.`);
                 }
             }
             generateMiddlewareStacks(db, tmpTrans);

--- a/src/classes/version/schema-helpers.ts
+++ b/src/classes/version/schema-helpers.ts
@@ -339,12 +339,10 @@ export function readGlobalSchema(db: Dexie, idbdb: IDBDatabase, tmpTrans: IDBTra
   setApiOnPlace(db, [db._allTables], keys(globalSchema), globalSchema);
 }
 
-export function verifyInstalledSchema(db: Dexie, idbdb: IDBDatabase, tmpTrans: IDBTransaction, declaredSchema: DbSchema) {
-  const installedSchema = buildGlobalSchema(db, idbdb, tmpTrans);
-  const diff = getSchemaDiff(installedSchema, declaredSchema);
-  if (diff.add.length || diff.change.some(ch => ch.add.length || ch.change.length)) {
-    throw new exceptions.Schema(`Version number passed to db.version() needs to be increased`);
-  }
+export function verifyInstalledSchema(db: Dexie, tmpTrans: IDBTransaction): boolean {
+  const installedSchema = buildGlobalSchema(db, db.idbdb, tmpTrans);
+  const diff = getSchemaDiff(installedSchema, db._dbSchema);
+  return !(diff.add.length || diff.change.some(ch => ch.add.length || ch.change.length));
 }
 
 export function adjustToExistingIndexNames(db: Dexie, schema: DbSchema, idbtrans: IDBTransaction) {

--- a/src/classes/version/schema-helpers.ts
+++ b/src/classes/version/schema-helpers.ts
@@ -339,6 +339,14 @@ export function readGlobalSchema(db: Dexie, idbdb: IDBDatabase, tmpTrans: IDBTra
   setApiOnPlace(db, [db._allTables], keys(globalSchema), globalSchema);
 }
 
+export function verifyInstalledSchema(db: Dexie, idbdb: IDBDatabase, tmpTrans: IDBTransaction, declaredSchema: DbSchema) {
+  const installedSchema = buildGlobalSchema(db, idbdb, tmpTrans);
+  const diff = getSchemaDiff(installedSchema, declaredSchema);
+  if (diff.add.length || diff.change.some(ch => ch.add.length || ch.change.length)) {
+    throw new exceptions.Schema(`Version number passed to db.version() needs to be increased`);
+  }
+}
+
 export function adjustToExistingIndexNames(db: Dexie, schema: DbSchema, idbtrans: IDBTransaction) {
   // Issue #30 Problem with existing db - adjust to existing index names when migrating from non-dexie db
   const storeNames = idbtrans.db.objectStoreNames;

--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -89,7 +89,7 @@ export function getUniqueArray(a) {
  *        instert on the resulting object for each item in the array. If this function returns a falsy value, the
  *        current item wont affect the resulting object.
  */
-export function arrayToObject (array, extractor) {
+export function arrayToObject<T,R> (array: T[], extractor: (x:T, idx: number)=>[string, R]): {[name: string]: R} {
     return array.reduce((result, item, i) => {
         var nameAndValue = extractor(item, i);
         if (nameAndValue) result[nameAndValue[0]] = nameAndValue[1];

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -343,7 +343,7 @@ asyncTest("PR #1108", async ()=>{
         db.close();
         warnings = [];
 
-        // Adding an index without updating version number:
+        // Adding a table without updating version number:
         db = new Dexie(DBNAME);
         db.version(1).stores({
             foo: "id",

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -317,3 +317,42 @@ asyncTest ("#1079 mapToClass", function(){
     }).finally(start);
 
 });
+
+asyncTest("#??? ", async ()=>{
+    const DBNAME = "IssueXXX";
+    let db = new Dexie(DBNAME);
+    db.version(1).stores({
+        foo: "id"
+    });
+    await db.open();
+    ok(true, `${DBNAME} could be opened`);
+    db.close();
+
+    // Adding an index without updating version number:
+    db = new Dexie(DBNAME);
+    db.version(1).stores({
+        foo: "id,name"
+    });
+    try {
+        await db.open();
+        ok(false, "Should not succeed to open a db with added index");
+    } catch (e) {
+        ok(e instanceof Dexie.SchemaError, "Should get SchemaError when a new index was declared without incrementing version number");
+    }
+    db.close();
+
+    // Adding an index without updating version number:
+    db = new Dexie(DBNAME);
+    db.version(1).stores({
+        foo: "id",
+        bar: ""
+    });
+    try {
+        await db.open();
+        ok(false, "Should not succeed to open a db with added table");
+    } catch (e) {
+        ok(e instanceof Dexie.SchemaError, "Should get SchemaError when a new table was declared without incrementing version number");
+    }
+    db.close();
+    start();
+});

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -318,12 +318,12 @@ asyncTest ("#1079 mapToClass", function(){
 
 });
 
-asyncTest("#??? ", async ()=>{
+asyncTest("PR #1108", async ()=>{
     const origConsoleWarn = console.warn;
     const warnings = [];
     console.warn = function(msg){warnings.push(msg); return origConsoleWarn.apply(this, arguments)};
     try {
-        const DBNAME = "IssueXXX";
+        const DBNAME = "PR1108";
         let db = new Dexie(DBNAME);
         db.version(1).stores({
             foo: "id"

--- a/test/tests-upgrading.js
+++ b/test/tests-upgrading.js
@@ -430,7 +430,7 @@ test("Issue #30 - Problem with existing db", (assert) => {
         db = new Dexie("raw-db", {addons: []}); // Explicitely don't use addons here. Syncable would fail to open an existing db.
         db.version(0.2).stores({
             people: "_id",
-            messages: "++,text,words,id,[size+color]",
+            messages: "++,text,*words,&id",
             umbrellas: "[date+time],[size+color]"
         });
         return db.open();


### PR DESCRIPTION
Warn on console in the case that the schema is altered without a version increment.
Don't fail, because this could destroy prod environments that works despite a faulty schema.
Warn unconditionally no matter the value of Dexie.debug. This is an important warning and it can be easily fixed by the user - just increment version number passed to db.version(...).