### PR TITLE
use error keys insted of values for typescript

### DIFF
--- a/src/errors/errors.d.ts
+++ b/src/errors/errors.d.ts
@@ -1,6 +1,7 @@
 import {
   DexieError,
   DexieErrorConstructor,
+  DexieErrors,
   ModifyError,
   ModifyErrorConstructor,
   BulkError,
@@ -17,6 +18,6 @@ export declare const exceptions : ExceptionAliasSet & {
   Type: ErrorConstructor,
   Range: ErrorConstructor
 };
-export declare const errnames : {[P in keyof ExceptionSet]: P};
+export declare const errnames : DexieErrors;
 export declare const fullNameExceptions : ExceptionSet;
 export declare function mapError (domError, message?) : DexieError;

--- a/src/public/types/dexie-constructor.d.ts
+++ b/src/public/types/dexie-constructor.d.ts
@@ -3,7 +3,7 @@ import { Transaction } from "./transaction";
 import { ThenShortcut } from "./then-shortcut";
 import { TableSchema } from "./table-schema";
 import { IndexSpec } from "./index-spec";
-import { DexieExceptionClasses } from "./errors";
+import { DexieExceptionClasses, DexieErrors } from "./errors";
 import { PromiseExtendedConstructor } from "./promise-extended";
 import { DexieEventSet } from "./dexie-event-set";
 import { DexieDOMDependencies } from "./dexie-dom-dependencies";
@@ -50,5 +50,5 @@ export interface DexieConstructor extends DexieExceptionClasses {
   //IndexSpec: {new():IndexSpec}; //? Deprecate
   Events: (ctx?: any)=>DexieEventSet;
 
-  errnames: {[P in keyof DexieExceptionClasses]: P};
+  errnames: DexieErrors;
 }


### PR DESCRIPTION
Hello,

I tried to check dexie error name in my typescript project next way:
```
  } catch (err) {
    switch (err.name) {
      case Dexie.errnames.Constraint:
        console.log('already exist')
        break
      default:
        console.log('other error')
    }
  }
```
And I have the next error:
```
Property 'Constraint' does not exist on type '{ OpenFailedError: "OpenFailedError"; VersionChangeError: "VersionChangeError"; SchemaError: "SchemaError"; UpgradeError: "UpgradeError"; InvalidTableError: "InvalidTableError"; ... 24 more ...; BulkError: "BulkError"; }'.
```

I think it's because you use values of error names as keys

But I'm new to TS so I may be wrong

Thanks!