### PR TITLE
Cleanup: ensure db.folks update hook is removed after unit test completion

### DIFF
--- a/test/tests-table.js
+++ b/test/tests-table.js
@@ -41,7 +41,7 @@ module("table", {
 });
 
 promisedTest("Issue #841 - put() ignores date changes", async ()=> {
-    db.folks.hook("updating", (mods) => {
+    const updateAssertions = (mods) => {
         equal(mods.first, first2, `first value should be ${first2} but is ${mods.first}`)
         
         equal(!!mods.date, true, "date should be included in modifications");
@@ -49,7 +49,8 @@ promisedTest("Issue #841 - put() ignores date changes", async ()=> {
         if (mods.date) {
             equal(mods.date.getTime(), date2.getTime(), `date should be ${date2} but is ${mods.date}`)
         }
-    });
+    };
+    db.folks.hook("updating", updateAssertions);
 
     const date1 = new Date("2019-05-03");
     const date2 = new Date("2020-01-01");
@@ -73,6 +74,8 @@ promisedTest("Issue #841 - put() ignores date changes", async ()=> {
     obj = await db.folks.get(id);
     equal(obj.first, first2, `first should have been successfully updated to '${first2}'`);
     equal(obj.date.getTime(), date2.getTime(), "Date should have been successfully updated to be date2");
+
+    db.folks.hook("updating").unsubscribe(updateAssertions);
 });
 
 asyncTest("get", 4, function () {


### PR DESCRIPTION
This is a small unit test cleanup discovered during preparation of an unrelated pull request.

One of the `Table` unit tests uses an `updating` hook to make assertions on the expected behaviour, but does not remove the hook after the unit test completes.

This cleanup ensures that the hook is removed, so that it doesn't run and apply assertions for any subsequent/unrelated unit tests.