### PR TITLE
Allow declaration-only tables for TS users.

### DIFF
--- a/src/classes/version/schema-helpers.ts
+++ b/src/classes/version/schema-helpers.ts
@@ -1,6 +1,6 @@
 import { Dexie } from '../dexie';
 import { DbSchema } from '../../public/types/db-schema';
-import { setProp, keys, slice, _global, isArray, shallowClone, isAsyncFunction, defineProperty } from '../../functions/utils';
+import { setProp, keys, slice, _global, isArray, shallowClone, isAsyncFunction, defineProperty, getPropertyDescriptor } from '../../functions/utils';
 import { Transaction } from '../transaction';
 import { Version } from './version';
 import Promise, { PSD, newScope, NativePromise, decrementExpectedAwaits, incrementExpectedAwaits } from '../../helpers/promise';
@@ -17,7 +17,9 @@ export function setApiOnPlace(db: Dexie, objs: Object[], tableNames: string[], d
   tableNames.forEach(tableName => {
     const schema = dbschema[tableName];
     objs.forEach(obj => {
-      if (!(tableName in obj)) {
+      const propDesc = getPropertyDescriptor(obj, tableName);
+      if (!propDesc || ("value" in propDesc && propDesc.value === undefined)) {
+        // Either the prop is not declared, or it is initialized to undefined.
         if (obj === db.Transaction.prototype || obj instanceof db.Transaction) {
           // obj is a Transaction prototype (or prototype of a subclass to Transaction)
           // Make the API a getter that returns this.table(tableName)


### PR DESCRIPTION
Due to how @babel/plugin-transform-typescript transpiles class fields, we had to change the Typescript recommendation of how to subclass Dexie. This commit makes it possible to go back to the previous recommendation in the docs - do only declare the classes and not have to manually initialize the tables in the constructor.

Plan: Wait with the docs updates until this commit has been released and then for another while until enough people have upgraded their Dexie to that version.

The docs should then be updated to propose a plain declaration of table properties, with an exclamation mark to hint about that the field is there despite not being assigned to in the constructor.

## Current recommendation:
```ts
class MyAppDatabase extends Dexie {
    contacts: Dexie.Table<IContact, number>; // number = type of the primkey

    constructor () {
        super("MyAppDatabase");
        this.version(1).stores({
            contacts: '++id, first, last',
        });

        // The following line is needed if your typescript
        // is compiled using babel instead of tsc:
        this.contacts = this.table("contacts");
    }
}
```

## New possible recommendation:
...when this change has reached enough end users:

```ts
class MyAppDatabase extends Dexie {
    contacts!: Dexie.Table<IContact, number>; // number = type of the primkey

    constructor () {
        super("MyAppDatabase");
        this.version(1).stores({
            contacts: '++id, first, last',
        });
    }
}
```
