### PR TITLE
Dexie.Observable: startObserving function: remove read-only query in order to avoid TransactionInactiveError

### DIFF
--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -255,6 +255,12 @@ function Observable(db) {
                             mySyncNodeShouldBecomeMaster = 0;
                         }
                     }
+
+                    // TODO: Why is this safety check required?
+                    // Without it, this test fails: https://github.com/dfahlander/Dexie.js/blob/77f0b08c58784bfaaf9e2f5e26dd4e1d7b7d3094/test/tests-exception-handling.js#L411-L494
+                    // ... due to an unhandled global TypeError: Cannot read property 'id' of null
+                    if (!mySyncNode.node) return;
+
                     // Assign the local node state
                     // This is guaranteed to apply *after* any existing master records have been inspected, due to the orderBy clause
                     if (existingNode.id === mySyncNode.node.id) {

--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -258,7 +258,7 @@ function Observable(db) {
                     // Assign the local node state
                     // This is guaranteed to apply *after* any existing master records have been inspected, due to the orderBy clause
                     if (existingNode.id === mySyncNode.node.id) {
-                        existingNode.isMaster = mySyncNodeShouldBecomeMaster;
+                        existingNode.isMaster = mySyncNode.node.isMaster = mySyncNodeShouldBecomeMaster;
                     }
                 });
             })).then(() => {

--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -256,9 +256,7 @@ function Observable(db) {
                         }
                     }
 
-                    // TODO: Why is this safety check required?
-                    // Without it, this test fails: https://github.com/dfahlander/Dexie.js/blob/77f0b08c58784bfaaf9e2f5e26dd4e1d7b7d3094/test/tests-exception-handling.js#L411-L494
-                    // ... due to an unhandled global TypeError: Cannot read property 'id' of null
+                    // The local node reference may be unassigned at any point by a database close() operation
                     if (!mySyncNode.node) return;
 
                     // Assign the local node state

--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -243,7 +243,7 @@ function Observable(db) {
             }
             // Add new sync node or if this is a reopening of the database after a close() call, update it.
             return db.transaction('rw', '_syncNodes', () => {
-                return db._syncNodes
+                var currentMaster = db._syncNodes
                     .where('isMaster').equals(1)
                     .first(currentMaster => {
                         if (!currentMaster) {
@@ -256,18 +256,23 @@ function Observable(db) {
                             currentMaster.isMaster = 0;
                             return db._syncNodes.put(currentMaster);
                         }
-                    }).then(()=>{
-                        // Add our node to DB and start subscribing to events
-                        return db._syncNodes.add(mySyncNode.node).then(function() {
-                            Observable.on('latestRevisionIncremented', onLatestRevisionIncremented); // Wakeup when a new revision is available.
-                            Observable.on('beforeunload', onBeforeUnload);
-                            Observable.on('suicideNurseCall', onSuicide);
-                            Observable.on('intercomm', onIntercomm);
-                            // Start polling for changes and do cleanups:
-                            pollHandle = setTimeout(poll, LOCAL_POLL);
-                            // Start heartbeat
-                            heartbeatHandle = setTimeout(heartbeat, HEARTBEAT_INTERVAL);
-                        });
+                    });
+                Promise.all([currentMaster]);
+
+                // Add our node to DB and start subscribing to events
+                var currentNode = db._syncNodes.add(mySyncNode.node).then(function() {
+                    Observable.on('latestRevisionIncremented', onLatestRevisionIncremented); // Wakeup when a new revision is available.
+                    Observable.on('beforeunload', onBeforeUnload);
+                    Observable.on('suicideNurseCall', onSuicide);
+                    Observable.on('intercomm', onIntercomm);
+                });
+                Promise.all([currentNode]);
+
+                return Dexie.ignoreTransaction(function() {
+                    // Start polling for changes and do cleanups:
+                    pollHandle = setTimeout(poll, LOCAL_POLL);
+                    // Start heartbeat
+                    heartbeatHandle = setTimeout(heartbeat, HEARTBEAT_INTERVAL);
                 });
             }).then(function () {
                 cleanup();

--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -242,7 +242,7 @@ function Observable(db) {
                 });
             }
             // Add new sync node or if this is a reopening of the database after a close() call, update it.
-            return db.transaction('rw', '_syncNodes', () => {
+            return Dexie.ignoreTransaction(() => {
                 return db._syncNodes
                     .where('isMaster').equals(1)
                     .first(currentMaster => {

--- a/addons/Dexie.Observable/src/Dexie.Observable.js
+++ b/addons/Dexie.Observable/src/Dexie.Observable.js
@@ -242,7 +242,7 @@ function Observable(db) {
                 });
             }
             // Add new sync node or if this is a reopening of the database after a close() call, update it.
-            return Dexie.ignoreTransaction(() => {
+            return db.transaction('rw', '_syncNodes', () => {
                 return db._syncNodes
                     .where('isMaster').equals(1)
                     .first(currentMaster => {


### PR DESCRIPTION
The cause of #1126 seems to relate to conflict between the (re)use of transactions on the `_syncNodes` Dexie-internal table after the `ready` trigger fires but before the database has completed opening.

The attempted fix here replaces two separate read & then write operations with a single-pass `modify` operation over the `db._syncNodes` internal table -- relying on [`Table.orderBy`](https://dexie.org/docs/Table/Table.orderBy()) to ensure that existing master sync node state is assessed before the 'local'  sync node record is updated -- within a  [`Dexie.ignoreTransaction`](https://dexie.org/docs/Dexie/Dexie.ignoreTransaction()) -- to retain atomicity, while avoiding re-use of the 'current' transaction.

Resolves #1126