### PR TITLE
Don't compare .src property of the primary index.

### DIFF
--- a/src/classes/version/schema-helpers.ts
+++ b/src/classes/version/schema-helpers.ts
@@ -229,10 +229,17 @@ export function getSchemaDiff(oldSchema: DbSchema, newSchema: DbSchema): SchemaD
         add: [],
         change: []
       };
-      if (oldDef.primKey.src !== newDef.primKey.src &&
-          !isIEOrEdge // IE and non-chromium Edge has a bug reading spec of primary key
-         ) 
-      { 
+      if (
+          (
+             // compare keyPaths no matter if string or string[]
+             // compare falsy keypaths same no matter if they are null or empty string.
+            ''+(oldDef.primKey.keyPath||'')
+          ) !== (
+            ''+(newDef.primKey.keyPath||'')
+          ) ||
+            // Compare the autoIncrement flag also
+          (oldDef.primKey.auto !== newDef.primKey.auto && !isIEOrEdge)) // IE has bug reading autoIncrement prop.
+      {
         // Primary key has changed. Remove and re-add table.
         change.recreate = true;
         diff.change.push(change);


### PR DESCRIPTION
The .src property is treated as being different if using dexie-observable's '$$' prefix, resulting in error when upgrading never works if using it.

Resolves issue #1148