### PR TITLE
Issue1154: WhereClause.equals(undefined) should fail

### DIFF
--- a/src/classes/where-clause/where-clause.ts
+++ b/src/classes/where-clause/where-clause.ts
@@ -55,6 +55,7 @@ export class WhereClause implements IWhereClause {
    * 
    **/
   equals(value: IndexableType) {
+    if (value == null) return fail(this, INVALID_KEY_ARGUMENT);
     return new this.Collection(this, () => rangeEqual(value)) as ICollection;
   }
 

--- a/test/tests-whereclause.js
+++ b/test/tests-whereclause.js
@@ -843,3 +843,21 @@ promisedTest("Virtual Index", async () => {
         ], null, 2), "equalsIgnoreCase() should work with virtual indexes");
     //equal(daves.length, 3, "There should be 3 davids in the result when using equalsIgnoreCase()");
 });
+
+promisedTest("WhereClause.equals(invalid key)", async () => {
+    await db.files.where("filename").equals(null).first().then(()=>{
+        ok(false, "db.files.where('filename').equals(null) must fail but it didnt!");
+    }).catch(error => {
+        ok(true, `db.files.where('filename').equals(null) failed as expected (with ${error})`);
+    });
+    await db.files.where("filename").equals(undefined).first().then(()=>{
+        ok(false, "db.files.where('filename').equals(undefined) must fail but it didnt!");
+    }).catch(error => {
+        ok(true, `db.files.where('filename').equals(undefined) failed as expected (with ${error})`);
+    });
+    await db.files.where("filename").equals(function(){}).first().then(()=>{
+        ok(false, "db.files.where('filename').equals(function(){}) must fail but it didnt!");
+    }).catch(error => {
+        ok(true, `db.files.where('filename').equals(function(){}) failed as expected (with ${error})`);
+    });
+});


### PR DESCRIPTION
In Dexie 3.0.0-3.0.2, WhereClause.equals(undefined) does not fail but instead returns all results order by the given field.
This is a regression as it did fail in Dexie 2.x.