### PR TITLE
Built-in observability: Collection.subscribe()

### DIFF
--- a/src/classes/dexie/dexie.ts
+++ b/src/classes/dexie/dexie.ts
@@ -124,7 +124,7 @@ export class Dexie implements IDexie {
     });
     this._state = state;
     this.name = name;
-    this.on = Events(this, "populate", "blocked", "versionchange", { ready: [promisableChain, nop] }) as DbEvents;
+    this.on = Events(this, "populate", "blocked", "versionchange", "mutate", { ready: [promisableChain, nop] }) as DbEvents;
     this.on.ready.subscribe = override(this.on.ready.subscribe, subscribe => {
       return (subscriber, bSticky) => {
         (Dexie as any as DexieConstructor).vip(() => {

--- a/src/classes/table/table.ts
+++ b/src/classes/table/table.ts
@@ -16,6 +16,7 @@ import { debug } from '../../helpers/debug';
 import { DBCoreTable } from '../../public/types/dbcore';
 import { AnyRange } from '../../dbcore/keyrange';
 import { workaroundForUndefinedPrimKey } from '../../functions/workaround-undefined-primkey';
+import { Observer, Subscription } from '../../public/types/observable';
 
 /** class Table
  * 
@@ -65,6 +66,18 @@ export class Table implements ITable<any, IndexableType> {
     } finally {
       if (wasRootExec) endMicroTickScope();
     }
+  }
+
+  subscribe(
+    onNext: (value: any[]) => void,
+    onError?: (error: any) => void,
+    onComplete?: () => void
+  ): Subscription;
+  subscribe(observer: Observer<any[]>): Subscription;
+  subscribe(): Subscription
+  {
+    const coll = this.toCollection();
+    return coll.subscribe.apply(coll, arguments);
   }
 
   /** Table.get()

--- a/src/dbcore/dbcore-indexeddb.ts
+++ b/src/dbcore/dbcore-indexeddb.ts
@@ -205,6 +205,12 @@ export function createDBCore (
         };
   
         req.onsuccess = done;
+      }).then(res => {
+        // Add the mutated table to the mutatedTables set on the transaction.
+        // Used by subscribers to txcommit event and for Collection.prototype.subscribe().
+        if (!trans.mutatedParts) trans.mutatedParts = {};
+        trans.mutatedParts[tableName] = true;
+        return res;
       });
     }
     

--- a/src/public/types/collection.d.ts
+++ b/src/public/types/collection.d.ts
@@ -4,8 +4,9 @@ import { WhereClause } from "./where-clause";
 import { PromiseExtended } from "./promise-extended";
 import { Database } from "./database";
 import { IndexableType } from "./indexable-type";
+import { Observable } from "./observable";
 
-export interface Collection<T=any, TKey=IndexableType> {
+export interface Collection<T=any, TKey=IndexableType> extends Observable<T[]> {
   //db: Database;
   and(filter: (x: T) => boolean): Collection<T, TKey>;
   clone(props?: Object): Collection<T, TKey>;

--- a/src/public/types/db-events.d.ts
+++ b/src/public/types/db-events.d.ts
@@ -20,13 +20,23 @@ export interface DexiePopulateEvent {
   fire(trans: Transaction): any;
 }
 
+export type MutatedParts = {[tableName: string]: true};
+
+export interface DexieOnMutateEvent {
+  subscribe(fn: (parts: MutatedParts) => any): void;
+  unsubscribe(fn: (parts: MutatedParts) => any): void;
+  fire(parts: MutatedParts): any;
+}
+
 export interface DbEvents extends DexieEventSet {
   (eventName: 'ready', subscriber: () => any, bSticky?: boolean): void;
   (eventName: 'populate', subscriber: (trans: Transaction) => any): void;
   (eventName: 'blocked', subscriber: (event: IDBVersionChangeEvent) => any): void;
   (eventName: 'versionchange', subscriber: (event: IDBVersionChangeEvent) => any): void;
+  (eventName: 'mutate', subscriber: (parts: MutatedParts)=>any): void;
   ready: DexieOnReadyEvent;
   populate: DexiePopulateEvent;
   blocked: DexieEvent;
-  versionchange: DexieVersionChangeEvent;        
+  versionchange: DexieVersionChangeEvent;
+  mutate: DexieOnMutateEvent;
 }

--- a/src/public/types/observable.d.ts
+++ b/src/public/types/observable.d.ts
@@ -1,0 +1,22 @@
+// There typings are extracted from https://github.com/tc39/proposal-observable
+
+export interface Observable<T = any> {
+  subscribe(
+    onNext: (value: T) => void,
+    onError?: (error: any) => void,
+    onComplete?: () => void
+  ): Subscription;
+  subscribe(observer: Observer<T>): Subscription;
+}
+
+export interface Subscription {
+  unsubscribe(): void;
+  readonly closed: boolean;
+}
+
+export interface Observer<T = any> {
+  start?: (subscription: Subscription) => void;
+  next?: (value: T) => void;
+  error?: (error: any) => void;
+  complete?: () => void;
+}

--- a/src/public/types/table.d.ts
+++ b/src/public/types/table.d.ts
@@ -8,8 +8,9 @@ import { PromiseExtended } from "./promise-extended";
 import { Database } from "./database";
 import { IndexableType } from "./indexable-type";
 import { DBCoreTable } from "./dbcore";
+import { Observable } from "./observable";
 
-export interface Table<T=any, TKey=IndexableType> {
+export interface Table<T=any, TKey=IndexableType> extends Observable<T[]> {
   db: Database;
   name: string;
   schema: TableSchema;


### PR DESCRIPTION
Make Collection & Table comply to es-observable's subscribe method.

https://github.com/tc39/proposal-observable

Should be compatible with RxJS. Needs to be verified.

Idea is to enable live queries without having to go with dexie-observable, since that addon affects performance by adding the mutations to a _changes table - which we really do not need here.

The limitation of this built-in observable capability is currently that it does not react ot DB mutations on other tabs/windows. However, is this really desired??? Do we want inactive tabs to start working and take performance from the computer when things happen in DB? If really needed, that functionality could be easily patched on top of this library by firing the new db.on.mutate event when storage event happens. Or in the case of a worker mutating data, it could be patched by letting the worker post message to frontend code that would fire the db.on.mutate event.