### PR TITLE
dbName follows dependencies.indexedDB (II)

### DIFF
--- a/src/classes/dexie/dexie-open.ts
+++ b/src/classes/dexie/dexie-open.ts
@@ -7,7 +7,7 @@ import Promise, { wrap } from '../../helpers/promise';
 import { connections } from '../../globals/constants';
 import { runUpgraders, readGlobalSchema, adjustToExistingIndexNames, verifyInstalledSchema } from '../version/schema-helpers';
 import { safariMultiStoreFix } from '../../functions/quirks';
-import { databaseEnumerator } from '../../helpers/database-enumerator';
+import { _onDatabaseCreated } from '../../helpers/database-enumerator';
 import { vip } from './vip';
 import { promisableChain, nop } from '../../functions/chaining-functions';
 import { generateMiddlewareStacks } from './generate-middleware-stacks';
@@ -102,7 +102,7 @@ export function dexieOpen (db: Dexie) {
               db.on("versionchange").fire(ev);
           });
           
-          databaseEnumerator.add(dbName);
+          _onDatabaseCreated(db._deps, dbName);
 
           resolve();
 

--- a/src/classes/dexie/dexie-static-props.ts
+++ b/src/classes/dexie/dexie-static-props.ts
@@ -2,7 +2,7 @@ import { Dexie as _Dexie } from './dexie';
 import { props, derive, extend, override, getByKeyPath, setByKeyPath, delByKeyPath, shallowClone, deepClone, getObjectDiff, asap, _global } from '../../functions/utils';
 import { fullNameExceptions } from '../../errors';
 import { DexieConstructor } from '../../public/types/dexie-constructor';
-import { DatabaseEnumerator, databaseEnumerator } from '../../helpers/database-enumerator';
+import { getDatabaseNames } from '../../helpers/database-enumerator';
 import { PSD } from '../../helpers/promise';
 import { usePSD } from '../../helpers/promise';
 import { newScope } from '../../helpers/promise';
@@ -64,9 +64,7 @@ props(Dexie, {
   // Static method for retrieving a list of all existing databases at current host.
   //
   getDatabaseNames(cb) {
-    return databaseEnumerator ?
-      databaseEnumerator.getDatabaseNames().then(cb) :
-      Promise.resolve([]);
+    return getDatabaseNames(Dexie.dependencies).then(cb);
   },
 
   /** @deprecated */

--- a/src/classes/dexie/dexie-static-props.ts
+++ b/src/classes/dexie/dexie-static-props.ts
@@ -64,7 +64,11 @@ props(Dexie, {
   // Static method for retrieving a list of all existing databases at current host.
   //
   getDatabaseNames(cb) {
-    return getDatabaseNames(Dexie.dependencies).then(cb);
+    try {
+      return getDatabaseNames(Dexie.dependencies).then(cb);
+    } catch {
+      return rejection(new exceptions.MissingAPI());
+    }
   },
 
   /** @deprecated */

--- a/src/classes/dexie/dexie.ts
+++ b/src/classes/dexie/dexie.ts
@@ -31,7 +31,7 @@ import { exceptions } from '../../errors';
 import { lowerVersionFirst } from '../version/schema-helpers';
 import { dexieOpen } from './dexie-open';
 import { wrap } from '../../helpers/promise';
-import { databaseEnumerator } from '../../helpers/database-enumerator';
+import { _onDatabaseDeleted } from '../../helpers/database-enumerator';
 import { eventRejectHandler } from '../../functions/event-wrappers';
 import { extractTransactionArgs, enterTransactionScope } from './transaction-helpers';
 import { TransactionMode } from '../../public/types/transaction-mode';
@@ -300,7 +300,7 @@ export class Dexie implements IDexie {
         this.close();
         var req = this._deps.indexedDB.deleteDatabase(this.name);
         req.onsuccess = wrap(() => {
-          databaseEnumerator.remove(this.name);
+          _onDatabaseDeleted(this._deps, this.name);
           resolve();
         });
         req.onerror = eventRejectHandler(reject);

--- a/src/helpers/database-enumerator.ts
+++ b/src/helpers/database-enumerator.ts
@@ -1,58 +1,59 @@
-import Promise from './promise';
-import { Dexie } from '../classes/dexie/dexie';
-import { Table } from '../public/types/table';
-import { nop } from '../functions/chaining-functions';
-import { PromiseExtended } from '../public/types/promise-extended';
-import { DBNAMES_DB } from '../globals/constants';
+import { Dexie } from "../classes/dexie/dexie";
+import { Table } from "../public/types/table";
+import { DBNAMES_DB } from "../globals/constants";
+import { DexieDOMDependencies } from "../public/types/dexie-dom-dependencies";
+import { nop } from "../functions/chaining-functions";
 
-export let databaseEnumerator: DatabaseEnumerator;
+type IDBKeyNamesVar = typeof IDBKeyRange;
 
-export interface DatabaseEnumerator {
-  getDatabaseNames (): PromiseExtended<string[]>;
-  add (name: string): undefined | PromiseExtended;
-  remove (name: string): undefined | PromiseExtended;
-}
-
-export function DatabaseEnumerator (indexedDB: IDBFactory & {databases?: ()=>Promise<{name: string}[]>}) : DatabaseEnumerator {
-  const hasDatabasesNative = indexedDB && typeof indexedDB.databases === 'function';
-  let dbNamesTable: Table<{name: string}, string>;
-
-  if (!hasDatabasesNative) {
-    const db = new Dexie (DBNAMES_DB, {addons: []});
-    db.version(1).stores({dbnames: 'name'});
-    dbNamesTable = db.table<{name: string}, string>('dbnames');
+function getDbNamesTable(indexedDB: IDBFactory, IDBKeyRange: IDBKeyNamesVar) {
+  let dbNamesDB = indexedDB["_dbNamesDB"];
+  if (!dbNamesDB) {
+    dbNamesDB = indexedDB["_dbNamesDB"] = new Dexie(DBNAMES_DB, {
+      addons: [],
+      indexedDB,
+      IDBKeyRange,
+    });
+    dbNamesDB.version(1).stores({ dbnames: "name" });
   }
-
-  return {
-    getDatabaseNames () {
-      return hasDatabasesNative
-        ?
-          // Use Promise.resolve() to wrap the native promise into a Dexie promise,
-          // to keep PSD zone.
-          Promise.resolve(indexedDB.databases()).then(infos => infos
-            // Select name prop of infos:
-            .map(info => info.name)
-            // Filter out DBNAMES_DB as previous Dexie or browser version would not have included it in the result.
-            .filter(name => name !== DBNAMES_DB)
-          )
-        :
-          // Use dexie's manually maintained list of database names:
-          dbNamesTable.toCollection().primaryKeys();
-    },
-
-    add (name: string) : PromiseExtended<any> | undefined {
-      return !hasDatabasesNative && name !== DBNAMES_DB && dbNamesTable.put({name}).catch(nop);
-    },
-
-    remove (name: string) : PromiseExtended<any> | undefined {
-      return !hasDatabasesNative && name !== DBNAMES_DB && dbNamesTable.delete(name).catch(nop);
-    }
-  };
+  return dbNamesDB.table("dbnames") as Table<{ name: string }, string>;
 }
 
-export function initDatabaseEnumerator(indexedDB: IDBFactory) {
-  try {
-    databaseEnumerator = DatabaseEnumerator(indexedDB);
-  } catch (e) {}
+function hasDatabasesNative(
+  indexedDB: IDBFactory & { databases?: () => Promise<{ name: string }[]> }
+): indexedDB is IDBFactory & { databases: () => Promise<{ name: string }[]> } {
+  return indexedDB && typeof indexedDB.databases === "function";
 }
 
+export function getDatabaseNames({
+  indexedDB,
+  IDBKeyRange,
+}: DexieDOMDependencies) {
+  return hasDatabasesNative(indexedDB)
+    ? Promise.resolve(indexedDB.databases()).then((infos) =>
+        infos
+          // Select name prop of infos:
+          .map((info) => info.name)
+          // Filter out DBNAMES_DB as previous Dexie or browser version would not have included it in the result.
+          .filter((name) => name !== DBNAMES_DB)
+      )
+    : getDbNamesTable(indexedDB, IDBKeyRange).toCollection().primaryKeys();
+}
+
+export function _onDatabaseCreated(
+  { indexedDB, IDBKeyRange }: DexieDOMDependencies,
+  name: string
+) {
+  !hasDatabasesNative(indexedDB) &&
+    name !== DBNAMES_DB &&
+    getDbNamesTable(indexedDB, IDBKeyRange).delete(name).catch(nop);
+}
+
+export function _onDatabaseDeleted(
+  { indexedDB, IDBKeyRange }: DexieDOMDependencies,
+  name: string
+) {
+  !hasDatabasesNative(indexedDB) &&
+    name !== DBNAMES_DB &&
+    getDbNamesTable(indexedDB, IDBKeyRange).delete(name).catch(nop);
+}

--- a/src/helpers/database-enumerator.ts
+++ b/src/helpers/database-enumerator.ts
@@ -46,7 +46,7 @@ export function _onDatabaseCreated(
 ) {
   !hasDatabasesNative(indexedDB) &&
     name !== DBNAMES_DB &&
-    getDbNamesTable(indexedDB, IDBKeyRange).delete(name).catch(nop);
+    getDbNamesTable(indexedDB, IDBKeyRange).put({name}).catch(nop);
 }
 
 export function _onDatabaseDeleted(

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,16 +4,12 @@ import { DexiePromise } from './helpers/promise';
 import { mapError } from './errors';
 import * as Debug from './helpers/debug';
 import { dexieStackFrameFilter } from './globals/constants';
-import { initDatabaseEnumerator } from './helpers/database-enumerator';
 
 // Generate all static properties such as Dexie.maxKey etc
 // (implement interface DexieConstructor):
 import './classes/dexie/dexie-static-props';
 import './live-query/enable-broadcast';
 import { liveQuery } from './live-query/live-query';
-
-// Init Database Enumerator (for Dexie.getDatabaseNames())
-initDatabaseEnumerator((Dexie as any as DexieConstructor).dependencies.indexedDB);
 
 // Set rejectionMapper of DexiePromise so that it generally tries to map
 // DOMErrors and DOMExceptions to a DexieError instance with same name but with

--- a/test/tests-asyncawait.js
+++ b/test/tests-asyncawait.js
@@ -3,7 +3,7 @@ import {module, test, equal, ok} from 'QUnit';
 import {resetDatabase, spawnedTest, promisedTest} from './dexie-unittest-utils';
 import {isIdbAndPromiseCompatible} from './is-idb-and-promise-compatible';
 
-const idbAndPromiseCompatible = isIdbAndPromiseCompatible();
+let idbAndPromiseCompatible;
 
 const hasNativeAsyncFunctions = false;
 try {
@@ -17,6 +17,8 @@ db.version(1).stores({
 
 module("asyncawait", {
     setup: function (assert) {
+        // Execute this promise when needed:
+        if (idbAndPromiseCompatible) idbAndPromiseCompatible = isIdbAndPromiseCompatible();
         let done = assert.async();
         resetDatabase(db).catch(function (e) {
             ok(false, "Error resetting database: " + e.stack);

--- a/test/tests-asyncawait.js
+++ b/test/tests-asyncawait.js
@@ -18,7 +18,10 @@ db.version(1).stores({
 module("asyncawait", {
     setup: function (assert) {
         // Execute this promise when needed:
-        if (idbAndPromiseCompatible) idbAndPromiseCompatible = isIdbAndPromiseCompatible();
+        if (idbAndPromiseCompatible === undefined) {
+            // Initialize this promise.
+            idbAndPromiseCompatible = isIdbAndPromiseCompatible();
+        }
         let done = assert.async();
         resetDatabase(db).catch(function (e) {
             ok(false, "Error resetting database: " + e.stack);


### PR DESCRIPTION
A lighter implementation of PR #820.

* Regard each indexedDB dependency as it's own "world".
* Switching Dexie.dependencies.indexedDB to another implementation should enumerate databases there and not regard databases created elsewhere to listed there.
* Creating a Dexie instance with {indexedDB, IDBKeyRange} set in options should act in that "world" if database is created or deleted.

Hopefully everything from PR #820 is included in this PR. I wanted to implement it more lightway without the need of classes as that could add unnescessary size to dexie.min.js. Hopefully this implementation is also easy to understand.

Note: The case when indexedDB isn't present or is behind a security policy was previously covered by a try...catch in initializeDbEnumerator() and checked for undefined whenever accessing that global variable. In this implementation we create the database enumerator on-demand, which makes this situation impossible to occur since it will only be created if a database was successfully added or deleted.
