### PR TITLE
Never treat array properties as delta-objects in update hook

### DIFF
--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -259,7 +259,7 @@ export const getValueOf = (val:any, type: string) =>
                 const bpTypeName = toStringTag(bp);
 
                 if (apTypeName === bpTypeName) {
-                    if (intrinsicTypeNameSet[apTypeName]) {
+                    if (intrinsicTypeNameSet[apTypeName] || isArray(ap)) {
                         // This is an intrinsic type. Don't go deep diffing it.
                         // Instead compare its value in best-effort:
                         // (Can compare real values of Date, ArrayBuffers and views)


### PR DESCRIPTION
When diffing 2 objects, treat array properties as intrinsic objects and never go into them to treat array indices as if they were object props.

Resolves #1195.