### PR TITLE
Expose close event

### DIFF
--- a/src/classes/dexie/dexie-open.ts
+++ b/src/classes/dexie/dexie-open.ts
@@ -100,6 +100,10 @@ export function dexieOpen (db: Dexie) {
               db.on("versionchange").fire(ev);
           });
           
+          idbdb.onclose = wrap(ev => {
+              db.on("close").fire(ev);
+          });
+
           _onDatabaseCreated(db._deps, dbName);
 
           resolve();

--- a/src/classes/dexie/dexie.ts
+++ b/src/classes/dexie/dexie.ts
@@ -126,7 +126,7 @@ export class Dexie implements IDexie {
     });
     this._state = state;
     this.name = name;
-    this.on = Events(this, "populate", "blocked", "versionchange", { ready: [promisableChain, nop] }) as DbEvents;
+    this.on = Events(this, "populate", "blocked", "versionchange", "close", { ready: [promisableChain, nop] }) as DbEvents;
     this.on.ready.subscribe = override(this.on.ready.subscribe, subscribe => {
       return (subscriber, bSticky) => {
         (Dexie as any as DexieConstructor).vip(() => {

--- a/src/public/types/db-events.d.ts
+++ b/src/public/types/db-events.d.ts
@@ -21,15 +21,23 @@ export interface DexiePopulateEvent {
   fire(trans: Transaction): any;
 }
 
+export interface DexieCloseEvent {
+  subscribe(fn: (event: Event) => any): void;
+  unsubscribe(fn: (event: Event) => any): void;
+  fire(event: Event): any;
+}
+
 export interface DbEvents extends DexieEventSet {
   (eventName: 'ready', subscriber: () => any, bSticky?: boolean): void;
   (eventName: 'populate', subscriber: (trans: Transaction) => any): void;
   (eventName: 'blocked', subscriber: (event: IDBVersionChangeEvent) => any): void;
   (eventName: 'versionchange', subscriber: (event: IDBVersionChangeEvent) => any): void;
+  (eventName: 'close', subscriber: (event: Event) => any): void;
   ready: DexieOnReadyEvent;
   populate: DexiePopulateEvent;
   blocked: DexieEvent;
   versionchange: DexieVersionChangeEvent;
+  close: DexieCloseEvent;
 }
 
 export type ObservabilitySet = {
@@ -45,6 +53,6 @@ export interface DexieOnTxCommittedEvent {
 }
 
 export interface GlobalDexieEvents extends DexieEventSet {
-  (eventName: 'txcommitted', subscriber: (parts: ObservabilitySet)=>any): void;
+  (eventName: 'txcommitted', subscriber: (parts: ObservabilitySet) => any): void;
   txcommitted: DexieOnTxCommittedEvent;
 }


### PR DESCRIPTION
Add the close event to the DbEvents list, so close event can be subscribed by doing this,
db.on('close'). This close event only fires if the database is unexpectedly closed.