### PR TITLE
Update package homepage link proto (HTTP to HTTPS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "engines": {
     "node": ">=6.0"
   },
-  "homepage": "http://dexie.org",
+  "homepage": "https://dexie.org",
   "devDependencies": {
     "dts-bundle-generator": "^1.6.1",
     "just-build": "^0.9.19",


### PR DESCRIPTION
Extremely minor; reduces HTTP redirects during sessions that open the link.  A lot of NPM packages seem to link to their homepages via HTTPS (this is visible when using some of the NPM CLI tools), so this stood out and looks like a small change.