### PR TITLE
Issue1225 again: liveQuery() fails to react on >50 bulk requests if previous resultset was empty

### DIFF
--- a/src/live-query/observability-middleware.ts
+++ b/src/live-query/observability-middleware.ts
@@ -90,9 +90,11 @@ export const observabilityMiddleware: Middleware<DBCore> = {
                 pkRangeSet.add(range);
               } else {
                 // Too many requests to record the details without slowing down write performance.
-                // Let's just record a generic large range
+                // Let's just record a generic large range on primary key, the virtual :dels index and
+                // all secondary indices:
                 pkRangeSet.add(FULL_RANGE);
                 delsRangeSet.add(FULL_RANGE);
+                schema.indexes.forEach(idx => getRangeSet(idx.name).add(FULL_RANGE));
               }
               return res;
             });


### PR DESCRIPTION
...as reopen reason for 1225 is - a special case that only seem to happen on outbound tables and bulk putting/adding >= 50 items and the query is a range that is open in one of its ends (like above()).