### PR TITLE
Preserve CryptoKey objects when adding to auto-incrementing table

### DIFF
--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -191,7 +191,7 @@ export function flatten<T> (a: (T | T[])[]) : T[] {
 
 //https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 const intrinsicTypeNames =
-    "Boolean,String,Date,RegExp,Blob,File,FileList,ArrayBuffer,DataView,Uint8ClampedArray,ImageData,Map,Set"
+    "Boolean,String,Date,RegExp,Blob,File,FileList,ArrayBuffer,DataView,Uint8ClampedArray,ImageData,Map,Set,CryptoKey"
     .split(',').concat(
         flatten([8,16,32,64].map(num=>["Int","Uint","Float"].map(t=>t+num+"Array")))
     ).filter(t=>_global[t]);

--- a/src/functions/workaround-undefined-primkey.ts
+++ b/src/functions/workaround-undefined-primkey.ts
@@ -1,7 +1,18 @@
 import { deepClone, delByKeyPath, getByKeyPath } from './utils';
 
+// This workaround is needed since obj could be a custom-class instance with an
+// uninitialized keyPath. See the following comment for more context:
+// https://github.com/dfahlander/Dexie.js/issues/1280#issuecomment-823557881
 export function workaroundForUndefinedPrimKey(keyPath: string | ArrayLike<string>) {
   return function (obj: object) {
+    // Skip this workaround if obj is NOT a custom class instance
+    if (
+      Object.getPrototypeOf(obj) === Object.prototype ||
+      Object.getPrototypeOf(obj) == null
+    ) {
+      return obj;
+    }
+
     if (getByKeyPath(obj, keyPath) === undefined) {
       obj = deepClone(obj);
       delByKeyPath(obj, keyPath);

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -393,3 +393,14 @@ asyncTest("Issue #1112", async ()=>{
         start();
     }
 });
+
+asyncTest("Issue #1280 - Don't perform deep-clone workaround when adding non-POJO to auto-incrementing table", async () => {
+    try {
+        await db.bars.add({ id: undefined, text: "hello1" });
+        ok(false, "Expected add() to fail since id is undefined");
+    } catch (error) {
+        ok(true);
+    } finally {
+        start();
+    }
+});

--- a/test/tests-table.js
+++ b/test/tests-table.js
@@ -536,6 +536,32 @@ spawnedTest("bulkAdd-catch sub transaction", function*(){
     equal(yield db.users.where('username').startsWith('aper').count(), 0, "0 users! Good, means that inner transaction did not commit");
 });
 
+spawnedTest("Issue #1280 - add() with auto-incrementing ID and CryptoKey", function* () {
+    var generatedKey = yield self.crypto.subtle.generateKey(
+        {
+            name: "RSA-OAEP",
+            modulusLength: 4096,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: "SHA-256",
+        },
+        true,
+        ["encrypt", "decrypt"],
+    );
+
+    var db = new Dexie("MyDatabaseToStoreCryptoKeys");
+    db.version(1).stores({
+        keys: "++id",
+    });
+    var objToAdd = { key: generatedKey.privateKey };
+    ok(generatedKey.privateKey instanceof CryptoKey, "The CryptoKey object was not generated correctly");
+
+    var id = yield db.keys.add(objToAdd);
+    ok(id != null, "Got unexpectedly nullish id");
+
+    var storedObj = yield db.keys.get(id);
+    ok(storedObj.key instanceof CryptoKey, "The CryptoKey object was destroyed in storage");
+});
+
 spawnedTest("bulkPut", function*(){
     var highestKey = yield db.users.add({username: "fsdkljfd", email: ["fjkljslk"]});
     ok(true, "Highest key was: " + highestKey);


### PR DESCRIPTION
As discussed in #1280, this PR:

- Adds `CryptoKey` to the list of IntrisicTypes to be preserved by the deep cloning algorithm.
- Modifies the "undefined primary key" workaround for auto-incrementing tables to only run on instances of user-defined classes (as opposed to plain-old JavaScript objects (POJO)).
- Adds unit tests for the above.

Suggestions and feedback are welcome. Thanks @dfahlander for your quick response and suggestions 😃 

Closes #1280.