### PR TITLE
Dont change global promise props2

### DIFF
--- a/src/helpers/promise.js
+++ b/src/helpers/promise.js
@@ -677,13 +677,7 @@ export function newScope (fn, props, a1, a2) {
     var globalEnv = globalPSD.env;
     psd.env = patchGlobalPromise ? {
         Promise: DexiePromise, // Changing window.Promise could be omitted for Chrome and Edge, where IDB+Promise plays well!
-        PromiseProp: {value: DexiePromise, configurable: true, writable: true},
-        all: DexiePromise.all,
-        race: DexiePromise.race,
-        allSettled: DexiePromise.allSettled,
-        any: DexiePromise.any,
-        resolve: DexiePromise.resolve,
-        reject: DexiePromise.reject
+        PromiseProp: {value: DexiePromise, configurable: true, writable: true}
     } : {};
     if (props) extend(psd, props);
     
@@ -782,15 +776,6 @@ function switchToZone (targetZone, bEnteringZone) {
 
             // Set this Promise to window.Promise so that transiled async functions will work on Firefox, Safari and IE, as well as with Zonejs and angular.
             Object.defineProperty(_global, 'Promise', targetEnv.PromiseProp);
-
-            // Support Promise.all() etc to work indexedDB-safe also when people are including es6-promise as a module (they might
-            // not be accessing global.Promise but a local reference to it)
-            GlobalPromise.all = targetEnv.all;
-            GlobalPromise.race = targetEnv.race;
-            GlobalPromise.resolve = targetEnv.resolve;
-            GlobalPromise.reject = targetEnv.reject;
-            if (targetEnv.allSettled) GlobalPromise.allSettled = targetEnv.allSettled;
-            if (targetEnv.any) GlobalPromise.any = targetEnv.any;
         }
     }
 }
@@ -799,13 +784,7 @@ function snapShot () {
     var GlobalPromise = _global.Promise;
     return patchGlobalPromise ? {
         Promise: GlobalPromise,
-        PromiseProp: Object.getOwnPropertyDescriptor(_global, "Promise"),
-        all: GlobalPromise.all,
-        race: GlobalPromise.race,
-        allSettled: GlobalPromise.allSettled,
-        any: GlobalPromise.any,
-        resolve: GlobalPromise.resolve,
-        reject: GlobalPromise.reject
+        PromiseProp: Object.getOwnPropertyDescriptor(_global, "Promise")
     } : {};
 }
 

--- a/src/helpers/promise.js
+++ b/src/helpers/promise.js
@@ -683,9 +683,7 @@ export function newScope (fn, props, a1, a2) {
         allSettled: DexiePromise.allSettled,
         any: DexiePromise.any,
         resolve: DexiePromise.resolve,
-        reject: DexiePromise.reject,
-        nthen: getPatchedPromiseThen (globalEnv.nthen, psd), // native then
-        gthen: getPatchedPromiseThen (globalEnv.gthen, psd) // global then
+        reject: DexiePromise.reject
     } : {};
     if (props) extend(psd, props);
     
@@ -779,11 +777,6 @@ function switchToZone (targetZone, bEnteringZone) {
         // Swich environments (may be PSD-zone or the global zone. Both apply.)
         var targetEnv = targetZone.env;
 
-        // Change Promise.prototype.then for native and global Promise (they MAY differ on polyfilled environments, but both can be accessed)
-        // Must be done on each zone change because the patched method contains targetZone in its closure.
-        nativePromiseProto.then = targetEnv.nthen;
-        GlobalPromise.prototype.then = targetEnv.gthen;
-
         if (currentZone.global || targetZone.global) {
             // Leaving or entering global zone. It's time to patch / restore global Promise.
 
@@ -812,9 +805,7 @@ function snapShot () {
         allSettled: GlobalPromise.allSettled,
         any: GlobalPromise.any,
         resolve: GlobalPromise.resolve,
-        reject: GlobalPromise.reject,
-        nthen: nativePromiseProto.then,
-        gthen: GlobalPromise.prototype.then
+        reject: GlobalPromise.reject
     } : {};
 }
 


### PR DESCRIPTION
This PR fails for 2 tests representing apps that imports Promise from a promise polyfill instead of just using the global Promise.

This is PR is based on #1293 but goes a step further.

Many apps and libs are still importing Promise from a polyfill to make them work on IE11. If these apps are doing Promise.resolve() or similar using the imported Promise constructor, we will not be able to track the ongoing transaction or liveQuery context if this commit is released.

Those apps will need to drag down the promise polyfill in a plain script tag instead of importing from the polyfill. The webpacked code must use the global Promise and not an imported one at any time within Dexie transactions and liveQuery querier functions.

This commit should be released in a new major version of Dexie with clear instrutions of how to migrate Promise polyfill dependent code.

We could also make an intermediate fix that is backward compliant but warns in console if they are using import polyfill-pattern (not part of this commit).

The upsides with this commit are:
* Optimization: We only switch self.Promise between zones.
* Simplicity: Less code
* Unobtrusiveness