### PR TITLE
Transaction.abort does not rollback changes

### DIFF
--- a/test/tests-transaction.js
+++ b/test/tests-transaction.js
@@ -976,3 +976,17 @@ promisedTest("db.transaction() should not wait for non-awaited new top-level tra
 
     equal(log.join(','), "outer-transaction-done,inner-transaction-done", "outer-transaction-done should have happened before inner-transaction-done");
 });
+
+asyncTest("abort will rollback previous writes", function() {
+    db.transaction('rw', db.users, function() {
+        db.users.add({ username: "james", color: "red" });
+        Dexie.currentTransaction.abort();
+    }).catch(function() {
+        ok(true, "transaction done");
+    }).then(function() {
+        return db.users.get('james')
+    }).then(function(user) {
+        ok(user == null, "should not written if transaction aborted");
+    })
+    .finally(start);
+});


### PR DESCRIPTION
I've written a test to demonstrate. The documentation [here](https://dexie.org/docs/Transaction/Transaction.abort()) states that abort `// Will discard all changes`, but it doesn't seem to for me. I ran this is chrome.