### PR TITLE
Resolves issue reproduced in PR #1329

### DIFF
--- a/src/classes/transaction/transaction.ts
+++ b/src/classes/transaction/transaction.ts
@@ -232,8 +232,7 @@ export class Transaction implements ITransaction {
    * http://dexie.org/docs/Transaction/Transaction.abort()
    */
   abort() {
-    this.active && this._reject(new exceptions.Abort());
-    this.active = false;
+    if (this.idbtrans) try {this.idbtrans.abort();} catch(_){}
   }
 
   /** Transaction.table()

--- a/src/classes/transaction/transaction.ts
+++ b/src/classes/transaction/transaction.ts
@@ -232,9 +232,10 @@ export class Transaction implements ITransaction {
    * http://dexie.org/docs/Transaction/Transaction.abort()
    */
   abort() {
-    if (this.active && this.idbtrans) {
+    if (this.active) {
       this.active = false;
-      this.idbtrans.abort();
+      if (this.idbtrans) this.idbtrans.abort();
+      this._reject(new exceptions.Abort());
     }
   }
 

--- a/src/classes/transaction/transaction.ts
+++ b/src/classes/transaction/transaction.ts
@@ -232,7 +232,10 @@ export class Transaction implements ITransaction {
    * http://dexie.org/docs/Transaction/Transaction.abort()
    */
   abort() {
-    if (this.idbtrans) try {this.idbtrans.abort();} catch(_){}
+    if (this.active && this.idbtrans) {
+      this.active = false;
+      this.idbtrans.abort();
+    }
   }
 
   /** Transaction.table()


### PR DESCRIPTION
Resolves issue with Transaction.abort() did not abort the transaction.
Reason was that Transaction.abort() set this.active to false, and rejected the promise. When promise rejection was catched, it should do the actual abort but it didnt to so because of the active state was already set to false by Transaction.abort().