### PR TITLE
Resolve issue 1270

### DIFF
--- a/src/classes/dexie/dexie-dom-dependencies.ts
+++ b/src/classes/dexie/dexie-dom-dependencies.ts
@@ -1,4 +1,4 @@
-import { _global } from '../../functions/utils';
+import { _global } from '../../globals/global';
 import { DexieDOMDependencies } from '../../public/types/dexie-dom-dependencies';
 
 export let domDeps: DexieDOMDependencies

--- a/src/classes/dexie/dexie-static-props.ts
+++ b/src/classes/dexie/dexie-static-props.ts
@@ -1,5 +1,7 @@
 import { Dexie as _Dexie } from './dexie';
-import { props, derive, extend, override, getByKeyPath, setByKeyPath, delByKeyPath, shallowClone, deepClone, getObjectDiff, asap, _global } from '../../functions/utils';
+import { _global } from '../../globals/global';
+import { props, derive, extend, override, getByKeyPath, setByKeyPath, delByKeyPath, shallowClone, deepClone, asap } from '../../functions/utils';
+import { getObjectDiff } from "../../functions/get-object-diff";
 import { fullNameExceptions } from '../../errors';
 import { DexieConstructor } from '../../public/types/dexie-constructor';
 import { getDatabaseNames } from '../../helpers/database-enumerator';

--- a/src/classes/version/schema-helpers.ts
+++ b/src/classes/version/schema-helpers.ts
@@ -1,6 +1,7 @@
 import { Dexie } from '../dexie';
 import { DbSchema } from '../../public/types/db-schema';
-import { setProp, keys, slice, _global, isArray, shallowClone, isAsyncFunction, defineProperty, getPropertyDescriptor } from '../../functions/utils';
+import { _global } from "../../globals/global";
+import { setProp, keys, slice, isArray, shallowClone, isAsyncFunction, defineProperty, getPropertyDescriptor } from '../../functions/utils';
 import { Transaction } from '../transaction';
 import { Version } from './version';
 import Promise, { PSD, newScope, NativePromise, decrementExpectedAwaits, incrementExpectedAwaits } from '../../helpers/promise';

--- a/src/functions/get-object-diff.ts
+++ b/src/functions/get-object-diff.ts
@@ -1,51 +1,39 @@
-import { keys, hasOwn, toStringTag, intrinsicTypeNameSet, isArray } from "./utils";
+import { keys, hasOwn, toStringTag } from './utils';
 
-export const getValueOf = (val:any, type: string) => 
-    type === "Array" ? ''+val.map(v => getValueOf(v, toStringTag(v))) :
-    type === "ArrayBuffer" ? ''+new Uint8Array(val) :
-    type === "Date" ? val.getTime() :
-    ArrayBuffer.isView(val) ? ''+new Uint8Array(val.buffer) :
-    val;
+export function getObjectDiff(a: any, b: any, rv?: any, prfx?: string) {
+  // Compares objects a and b and produces a diff object.
+  rv = rv || {};
+  prfx = prfx || '';
+  keys(a).forEach((prop) => {
+    if (!hasOwn(b, prop)) {
+      // Property removed
+      rv[prfx + prop] = undefined;
+    } else {
+      var ap = a[prop],
+        bp = b[prop];
+      if (typeof ap === 'object' && typeof bp === 'object' && ap && bp) {
+        const apTypeName = toStringTag(ap);
+        const bpTypeName = toStringTag(bp);
 
- export function getObjectDiff(a, b, rv?, prfx?) {
-    // Compares objects a and b and produces a diff object.
-    rv = rv || {};
-    prfx = prfx || '';
-    keys(a).forEach(prop => {
-        if (!hasOwn(b, prop))
-            rv[prfx+prop] = undefined; // Property removed
-        else {
-            var ap = a[prop],
-                bp = b[prop];
-            if (typeof ap === 'object' && typeof bp === 'object' && ap && bp)
-            {
-                const apTypeName = toStringTag(ap);
-                const bpTypeName = toStringTag(bp);
-
-                if (apTypeName === bpTypeName) {
-                    if (intrinsicTypeNameSet[apTypeName] || isArray(ap)) {
-                        // This is an intrinsic type. Don't go deep diffing it.
-                        // Instead compare its value in best-effort:
-                        // (Can compare real values of Date, ArrayBuffers and views)
-                        if (getValueOf(ap, apTypeName) !== getValueOf(bp, bpTypeName)) {
-                            rv[prfx + prop] = b[prop]; // Date / ArrayBuffer etc is of different value
-                        }
-                    } else {
-                        // This is not an intrinsic object. Compare the it deeply:
-                        getObjectDiff(ap, bp, rv, prfx + prop + ".");
-                    }
-                } else {
-                    rv[prfx + prop] = b[prop];// Property changed to other type
-                }                
-            } else if (ap !== bp)
-                rv[prfx + prop] = b[prop];// Primitive value changed
+        if (apTypeName !== bpTypeName) {
+          rv[prfx + prop] = b[prop]; // Property changed to other type
+        } else if (apTypeName === 'Object') {
+          // Pojo objects (not Date, ArrayBuffer, Array etc). Go deep.
+          getObjectDiff(ap, bp, rv, prfx + prop + '.');
+        } else if (ap !== bp) {
+          // Values differ.
+          // Could have checked if Date, arrays or binary types have same
+          // content here but I think that would be a suboptimation.
+          // Prefer simplicity.
+          rv[prfx + prop] = b[prop];
         }
-    });
-    keys(b).forEach(prop => {
-        if (!hasOwn(a, prop)) {
-            rv[prfx+prop] = b[prop]; // Property added
-        }
-    });
-    return rv;
+      } else if (ap !== bp) rv[prfx + prop] = b[prop]; // Primitive value changed
+    }
+  });
+  keys(b).forEach((prop) => {
+    if (!hasOwn(a, prop)) {
+      rv[prfx + prop] = b[prop]; // Property added
+    }
+  });
+  return rv;
 }
-

--- a/src/functions/get-object-diff.ts
+++ b/src/functions/get-object-diff.ts
@@ -1,0 +1,51 @@
+import { keys, hasOwn, toStringTag, intrinsicTypeNameSet, isArray } from "./utils";
+
+export const getValueOf = (val:any, type: string) => 
+    type === "Array" ? ''+val.map(v => getValueOf(v, toStringTag(v))) :
+    type === "ArrayBuffer" ? ''+new Uint8Array(val) :
+    type === "Date" ? val.getTime() :
+    ArrayBuffer.isView(val) ? ''+new Uint8Array(val.buffer) :
+    val;
+
+ export function getObjectDiff(a, b, rv?, prfx?) {
+    // Compares objects a and b and produces a diff object.
+    rv = rv || {};
+    prfx = prfx || '';
+    keys(a).forEach(prop => {
+        if (!hasOwn(b, prop))
+            rv[prfx+prop] = undefined; // Property removed
+        else {
+            var ap = a[prop],
+                bp = b[prop];
+            if (typeof ap === 'object' && typeof bp === 'object' && ap && bp)
+            {
+                const apTypeName = toStringTag(ap);
+                const bpTypeName = toStringTag(bp);
+
+                if (apTypeName === bpTypeName) {
+                    if (intrinsicTypeNameSet[apTypeName] || isArray(ap)) {
+                        // This is an intrinsic type. Don't go deep diffing it.
+                        // Instead compare its value in best-effort:
+                        // (Can compare real values of Date, ArrayBuffers and views)
+                        if (getValueOf(ap, apTypeName) !== getValueOf(bp, bpTypeName)) {
+                            rv[prfx + prop] = b[prop]; // Date / ArrayBuffer etc is of different value
+                        }
+                    } else {
+                        // This is not an intrinsic object. Compare the it deeply:
+                        getObjectDiff(ap, bp, rv, prfx + prop + ".");
+                    }
+                } else {
+                    rv[prfx + prop] = b[prop];// Property changed to other type
+                }                
+            } else if (ap !== bp)
+                rv[prfx + prop] = b[prop];// Primitive value changed
+        }
+    });
+    keys(b).forEach(prop => {
+        if (!hasOwn(a, prop)) {
+            rv[prfx+prop] = b[prop]; // Property added
+        }
+    });
+    return rv;
+}
+

--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -1,10 +1,6 @@
-﻿declare var global;
+﻿import { _global } from "../globals/global";
 export const keys = Object.keys;
 export const isArray = Array.isArray;
-const _global =
-    typeof self !== 'undefined' ? self :
-    typeof window !== 'undefined' ? window :
-    global;
 if (typeof Promise !== 'undefined' && !_global.Promise){
     // In jsdom, this it can be the case that Promise is not put on the global object.
     // If so, we need to patch the global object for the rest of the code to work as expected.
@@ -196,7 +192,7 @@ const intrinsicTypeNames =
         flatten([8,16,32,64].map(num=>["Int","Uint","Float"].map(t=>t+num+"Array")))
     ).filter(t=>_global[t]);
 const intrinsicTypes = intrinsicTypeNames.map(t=>_global[t]);
-const intrinsicTypeNameSet = arrayToObject(intrinsicTypeNames, x=>[x,true]);
+export const intrinsicTypeNameSet = arrayToObject(intrinsicTypeNames, x=>[x,true]);
 
 let circularRefs: null | WeakMap<any,any> = null;
 export function deepClone<T>(any: T): T {
@@ -234,55 +230,6 @@ function innerDeepClone<T>(any: T): T {
 const {toString} = {};
 export function toStringTag(o: Object) {
     return toString.call(o).slice(8, -1);
-}
-
-export const getValueOf = (val:any, type: string) => 
-    type === "Array" ? ''+val.map(v => getValueOf(v, toStringTag(v))) :
-    type === "ArrayBuffer" ? ''+new Uint8Array(val) :
-    type === "Date" ? val.getTime() :
-    ArrayBuffer.isView(val) ? ''+new Uint8Array(val.buffer) :
-    val;
-
- export function getObjectDiff(a, b, rv?, prfx?) {
-    // Compares objects a and b and produces a diff object.
-    rv = rv || {};
-    prfx = prfx || '';
-    keys(a).forEach(prop => {
-        if (!hasOwn(b, prop))
-            rv[prfx+prop] = undefined; // Property removed
-        else {
-            var ap = a[prop],
-                bp = b[prop];
-            if (typeof ap === 'object' && typeof bp === 'object' && ap && bp)
-            {
-                const apTypeName = toStringTag(ap);
-                const bpTypeName = toStringTag(bp);
-
-                if (apTypeName === bpTypeName) {
-                    if (intrinsicTypeNameSet[apTypeName] || isArray(ap)) {
-                        // This is an intrinsic type. Don't go deep diffing it.
-                        // Instead compare its value in best-effort:
-                        // (Can compare real values of Date, ArrayBuffers and views)
-                        if (getValueOf(ap, apTypeName) !== getValueOf(bp, bpTypeName)) {
-                            rv[prfx + prop] = b[prop]; // Date / ArrayBuffer etc is of different value
-                        }
-                    } else {
-                        // This is not an intrinsic object. Compare the it deeply:
-                        getObjectDiff(ap, bp, rv, prfx + prop + ".");
-                    }
-                } else {
-                    rv[prfx + prop] = b[prop];// Property changed to other type
-                }                
-            } else if (ap !== bp)
-                rv[prfx + prop] = b[prop];// Primitive value changed
-        }
-    });
-    keys(b).forEach(prop => {
-        if (!hasOwn(a, prop)) {
-            rv[prfx+prop] = b[prop]; // Property added
-        }
-    });
-    return rv;
 }
 
 // If first argument is iterable or array-like, return it as an array

--- a/src/globals/global.ts
+++ b/src/globals/global.ts
@@ -1,0 +1,6 @@
+declare var global;
+export const _global: any =
+    typeof globalThis !== 'undefined' ? globalThis :
+    typeof self !== 'undefined' ? self :
+    typeof window !== 'undefined' ? window :
+    global;

--- a/src/helpers/promise.js
+++ b/src/helpers/promise.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2017 David Fahlander
  * Apache License Version 2.0, January 2004, http://www.apache.org/licenses/LICENSE-2.0
  */
+import { _global } from '../globals/global';
 import {tryCatch, props, setProp, _global,
     getPropertyDescriptor, getArrayOf, extend, getProto} from '../functions/utils';
 import {nop, callBoth, mirror} from '../functions/chaining-functions';

--- a/src/hooks/hooks-middleware.ts
+++ b/src/hooks/hooks-middleware.ts
@@ -10,7 +10,8 @@ import {
   DBCoreKeyRange
 } from "../public/types/dbcore";
 import { nop } from '../functions/chaining-functions';
-import { getObjectDiff, hasOwn, setByKeyPath } from '../functions/utils';
+import { hasOwn, setByKeyPath } from '../functions/utils';
+import { getObjectDiff } from "../functions/get-object-diff";
 import { PSD } from '../helpers/promise';
 //import { LockableTableMiddleware } from '../dbcore/lockable-table-middleware';
 import { getEffectiveKeys } from '../dbcore/get-effective-keys';

--- a/test/tests-table.js
+++ b/test/tests-table.js
@@ -6,6 +6,7 @@ var db = new Dexie("TestDBTable");
 db.version(1).stores({
     users: "++id,first,last,&username,*&email,*pets",
     folks: "++,first,last",
+    items: "id",
     schema: "" // Test issue #1039
 });
 
@@ -94,6 +95,13 @@ promisedTest("Issue #966 - put() with dotted field in update hook", async () => 
     equal(obj.nested, undefined, "obj.nested field should have remained undefined");
 
     db.folks.hook("updating").unsubscribe(updateAssertions);
+});
+
+promisedTest("update array property", async () => {
+    const id = await db.items.put({id: 1, foo: [{bar: 123}]});
+    await db.items.update(1, {foo: [{bar: 222}]});
+    const obj = await db.items.get(1);
+    equal(JSON.stringify(obj.foo), JSON.stringify([{bar: 222}]), "foo har been updated to the new array");
 });
 
 promisedTest("Verify #1130 doesn't break contract of hook('updating')", async ()=>{


### PR DESCRIPTION
This PR resolves #1720 by simplifying getObjectDiff a bit. Keeping the other current behaviour of diffing nested POJO objects but treating array properties and other exotic types as always diffing.

This PR replaces #1272.