### PR TITLE
Changes and bugfixes done during dexie-cloud development

### DIFF
--- a/src/classes/dexie/dexie-open.ts
+++ b/src/classes/dexie/dexie-open.ts
@@ -117,7 +117,10 @@ export function dexieOpen (db: Dexie) {
       // Dexie.vip() makes subscribers able to use the database while being opened.
       // This is a must since these subscribers take part of the opening procedure.
       state.onReadyBeingFired = [];
-      return Promise.resolve(vip(db.on.ready.fire)).then(function fireRemainders() {
+      const vipedDb = Object.create(db) as Dexie;
+      vipedDb._state = Object.create(db._state);
+      vipedDb._state.openComplete = true;
+      return Promise.resolve(vip(()=>db.on.ready.fire(vipedDb))).then(function fireRemainders() {
           if (state.onReadyBeingFired.length > 0) {
               // In case additional subscribers to db.on('ready') were added during the time db.on.ready.fire was executed.
               let remainders = state.onReadyBeingFired.reduce(promisableChain, nop);

--- a/src/classes/dexie/dexie-static-props.ts
+++ b/src/classes/dexie/dexie-static-props.ts
@@ -49,7 +49,7 @@ props(Dexie, {
   // Static delete() method.
   //
   delete(databaseName: string) {
-    const db = new Dexie(databaseName);
+    const db = new Dexie(databaseName, {addons: []});
     return db.delete();
   },
 

--- a/src/classes/observable/observable.ts
+++ b/src/classes/observable/observable.ts
@@ -16,14 +16,14 @@ export class Observable<T> implements IObservable<T> {
   }
 
   subscribe(
-    onNext: (value: T) => void,
-    onError?: (error: any) => void,
-    onComplete?: () => void
+    onNext?: ((value: T) => void) | null,
+    onError?: ((error: any) => void) | null,
+    onComplete?: (() => void) | null
   ): Subscription;
-  subscribe(observer: Observer<T>): Subscription;
-  subscribe(x: any, error?: any, complete?: any): Subscription {
+  subscribe(observer?: Observer<T> | null): Subscription;
+  subscribe(x?: any, error?: any, complete?: any): Subscription {
     return this._subscribe(
-      typeof x === "function" ? { next: x, error, complete } : x
+      !x || typeof x === "function" ? { next: x, error, complete } : x
     );
   }
 

--- a/src/classes/transaction/transaction.ts
+++ b/src/classes/transaction/transaction.ts
@@ -113,7 +113,12 @@ export class Transaction implements ITransaction {
     if (!this.active) throw new exceptions.TransactionInactive();
     assert(this._completion._state === null); // Completion Promise must still be pending.
 
-    idbtrans = this.idbtrans = idbtrans || idbdb.transaction(safariMultiStoreFix(this.storeNames), this.mode) as IDBTransaction;
+    idbtrans = this.idbtrans = idbtrans ||
+      (this.db.core 
+        ? this.db.core.transaction(this.storeNames, this.mode as 'readwrite' | 'readonly')
+        : idbdb.transaction(this.storeNames, this.mode)
+      ) as IDBTransaction;
+
     idbtrans.onerror = wrap(ev => {
       preventDefault(ev);// Prohibit default bubbling to window.error
       this._reject(idbtrans.error);

--- a/src/classes/version/version.ts
+++ b/src/classes/version/version.ts
@@ -6,6 +6,7 @@ import { Transaction } from '../transaction';
 import { removeTablesApi, setApiOnPlace, parseIndexSyntax } from './schema-helpers';
 import { exceptions } from '../../errors';
 import { createTableSchema } from '../../helpers/table-schema';
+import { nop, promisableChain } from '../../functions/chaining-functions';
 
 /** class Version
  *
@@ -61,7 +62,7 @@ export class Version implements IVersion {
   }
 
   upgrade(upgradeFunction: (trans: Transaction) => PromiseLike<any> | void): Version {
-    this._cfg.contentUpgrade = upgradeFunction;
+    this._cfg.contentUpgrade = promisableChain(this._cfg.contentUpgrade || nop, upgradeFunction);
     return this;
   }
 }

--- a/src/dbcore/virtual-index-middleware.ts
+++ b/src/dbcore/virtual-index-middleware.ts
@@ -55,7 +55,6 @@ export function createVirtualIndexMiddleware (down: DBCore) : DBCore {
         const virtualIndex = {
           ...lowLevelIndex,
           isVirtual,
-          isPrimaryKey: !isVirtual && lowLevelIndex.isPrimaryKey,
           keyTail,
           keyLength,
           extractKey: getKeyExtractor(keyPath),

--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -240,6 +240,9 @@ export const getIteratorOf = typeof iteratorSymbol === "symbol" ? function(x) {
     var i;
     return x != null && (i = x[iteratorSymbol]) && i.apply(x);
 } : function () { return null; };
+export const asyncIteratorSymbol = typeof Symbol !== 'undefined'
+    ? Symbol.asyncIterator || Symbol.for("Symbol.asyncIterator")
+    : '@asyncIterator';
 
 export const NO_CHAR_ARRAY = {};
 // Takes one or several arguments and returns an array based on the following criteras:

--- a/src/live-query/enable-broadcast.ts
+++ b/src/live-query/enable-broadcast.ts
@@ -2,8 +2,8 @@ import { globalEvents } from "../globals/global-events";
 import { propagateLocally, propagatingLocally } from "./propagate-locally";
 
 if (typeof BroadcastChannel !== "undefined") {
-  const bc = new BroadcastChannel('dexie-txcommitted');
-  
+  const bc = new BroadcastChannel("dexie-txcommitted");
+
   //
   // Propagate local changes to remote tabs, windows and workers via BroadcastChannel
   //
@@ -16,24 +16,39 @@ if (typeof BroadcastChannel !== "undefined") {
   //
   // Propagate remote changes locally via storage event:
   //
-  bc.onmessage = ev => {
+  bc.onmessage = (ev) => {
     if (ev.data) propagateLocally(ev.data);
   };
-} else if (typeof localStorage !== "undefined") {
-
+} else if (typeof self !== "undefined" && typeof navigator !== "undefined") {
+  // DOM verified - when typeof self !== "undefined", we are a window or worker. Not a Node process.
+  
   //
-  // Propagate local changes to remote tabs/windows via storage event:
+  // Propagate local changes to remote tabs/windows via storage event and service worker
+  // via messages. We have this code here because of https://bugs.webkit.org/show_bug.cgi?id=161472.
   //
   globalEvents("txcommitted", (changedParts) => {
     try {
       if (!propagatingLocally) {
-        localStorage.setItem(
-          "dexie-txcommitted",
-          JSON.stringify({
-            trig: Math.random(),
-            changedParts,
-          })
-        );
+        if (typeof localStorage !== "undefined") {
+          // We're a browsing window or tab. Propagate to other windows/tabs via storage event:
+          localStorage.setItem(
+            "dexie-txcommitted",
+            JSON.stringify({
+              trig: Math.random(),
+              changedParts,
+            })
+          );
+        }
+        if (typeof self["clients"] === "object") {
+          // We're a service worker. Propagate to our browser clients.
+          [...self["clients"].matchAll({ includeUncontrolled: true })].forEach(
+            (client) =>
+              client.postMessage({
+                type: "dexie-txcommitted",
+                changedParts,
+              })
+          );
+        }        
       }
     } catch {}
   });
@@ -47,5 +62,20 @@ if (typeof BroadcastChannel !== "undefined") {
       if (data) propagateLocally(data.changedParts);
     }
   });
+
+
+  //
+  // Propagate messages from service worker
+  //
+  const swContainer = self.document && navigator.serviceWorker; // self.document is to verify we're not the SW ourself
+  if (swContainer) {
+    // We're a browser window and want to propagate message from the SW:
+    swContainer.addEventListener('message', propagateMessageLocally);
+  }
 }
 
+function propagateMessageLocally({data}: MessageEvent) {
+  if (data && data.type === "dexie-txcommitted") {
+    propagateLocally(data.changedParts);
+  }
+}

--- a/src/public/types/db-events.d.ts
+++ b/src/public/types/db-events.d.ts
@@ -1,12 +1,13 @@
 import { DexieEventSet } from "./dexie-event-set";
 import { DexieEvent } from "./dexie-event";
 import { Transaction } from "./transaction";
+import { Dexie } from "./dexie";
 import { IntervalTree } from "./rangeset";
 
 export interface DexieOnReadyEvent {
-  subscribe(fn: () => any, bSticky: boolean): void;
-  unsubscribe(fn: () => any): void;
-  fire(): any;
+  subscribe(fn: (vipDb: Dexie) => any, bSticky: boolean): void;
+  unsubscribe(fn: (vipDb: Dexie) => any): void;
+  fire(vipDb: Dexie): any;
 }
 
 export interface DexieVersionChangeEvent {
@@ -28,7 +29,7 @@ export interface DexieCloseEvent {
 }
 
 export interface DbEvents extends DexieEventSet {
-  (eventName: 'ready', subscriber: () => any, bSticky?: boolean): void;
+  (eventName: 'ready', subscriber: (vipDb: Dexie) => any, bSticky?: boolean): void;
   (eventName: 'populate', subscriber: (trans: Transaction) => any): void;
   (eventName: 'blocked', subscriber: (event: IDBVersionChangeEvent) => any): void;
   (eventName: 'versionchange', subscriber: (event: IDBVersionChangeEvent) => any): void;

--- a/src/public/types/dbcore.d.ts
+++ b/src/public/types/dbcore.d.ts
@@ -20,11 +20,6 @@ export interface DBCoreTransaction {
   abort(): void;
 }
 
-export interface DBCoreTransactionRequest {
-  tables: string[];
-  mode: 'readonly' | 'readwrite';
-}
-
 export type DBCoreMutateRequest = DBCoreAddRequest | DBCorePutRequest | DBCoreDeleteRequest | DBCoreDeleteRangeRequest;
 
 export interface DBCoreMutateResponse {
@@ -48,6 +43,12 @@ export interface DBCorePutRequest {
   trans: DBCoreTransaction;
   values: any[];
   keys?: any[];
+  criteria?: {
+    index: string | null;
+    range: DBCoreKeyRange;
+  };
+  changeSpec?: {[keyPath: string]: any}; // Common changeSpec for each key
+  changeSpecs?: {[keyPath: string]: any}[]; // changeSpec per key. 
   /** @deprecated Will always get results since 3.1.0-alpha.5 */
   wantResults?: boolean;
 }
@@ -56,6 +57,10 @@ export interface DBCoreDeleteRequest {
   type: 'delete';
   trans: DBCoreTransaction;
   keys: any[];
+  criteria?: {
+    index: string | null;
+    range: DBCoreKeyRange;
+  };
 }
 
 export interface DBCoreDeleteRangeRequest {
@@ -150,11 +155,10 @@ export interface DBCoreIndex {
   /** Extract (using keyPath) a key from given value (object). Null for outbound primary keys */
   readonly extractKey: ((value: any) => any) | null;
 }
-
 export interface DBCore {
   stack: "dbcore";
   // Transaction and Object Store
-  transaction(req: DBCoreTransactionRequest): DBCoreTransaction;
+  transaction(stores: string[], mode: 'readonly' | 'readwrite'): DBCoreTransaction;
 
   // Utility methods
   cmp(a: any, b: any) : number;

--- a/src/public/types/observable.d.ts
+++ b/src/public/types/observable.d.ts
@@ -2,11 +2,11 @@
 
 export interface Observable<T = any> {
   subscribe(
-    onNext: (value: T) => void,
-    onError?: (error: any) => void,
-    onComplete?: () => void
+    onNext?: ((value: T) => void) | null,
+    onError?: ((error: any) => void) | null,
+    onComplete?: (() => void) | null
   ): Subscription;
-  subscribe(observer: Observer<T>): Subscription;
+  subscribe(observer?: Observer<T> | null): Subscription;
 }
 
 export interface Subscription {


### PR DESCRIPTION
A few changes:

## Using DBCore.transaction()
Before, we didn't call DBCore.transaction() internally to allow middlewares to intercept transaction creation. This PR corrects that and also added a second argument for which tables / object stores to include in the transaction. This allows for DBCore middlewares to inject code into both implicit and explicit transactions.

## Supplying more information to DBCoreTable.mutate().
DBCoreMutateRequest has been extended with optional parameters `criteria` and `changeSpec`. This allows for middlewares to understand the intent of the mutation (which range-query that was the criteria for the change, and which properties that is meant to be updated). For Dexie Cloud, this feature makes it possible perform consistent operations across peers and maintain offline consistency for range- or index based calls to Collection.modify() and Collection.delete().

## Bugfix in virtual index
Couldn't reuse parts of primary keys - only parts of indexes.

## Safari workaround: Mutations in a service worker weren't propagated to liveQuery() in browser windows.
Dexie's liveQuery() functionality broadcasts changes using [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel) which is not supported on Safari. To workaround this, we've so far been using localStorage/onstorage to communicate changes across tabs. This workaround was eventually broken with the latest release of Safari where localStorage became broken when having multiple tabs open. Also the workarond didn't solve broadcasting changes between service worker and tabs/windows. This change makes mutations that are made in the service worker propagate to all service worker clients - which can be tabs/windows or other workers, so that liveQuery() observables will emit correctly when changes are made in the service worker - also on Safari. For other browsers, this hasn't been a problem.

## Other changes:
* Dexie.delete() specifies an empty addons list to ensure no addons are involved when deleting a database using that static method.
* Correcting typescript Observable<T> interface to better comply with RxJs.
* Retiring old workaround for safari 8 bug not allowing array argument to IDBDatabase.transaction().
* Allow multiple calls to Version.upgrade() on the same version - will run all of them instead just of the latest registered.
* Argument to on.ready() callback will get a special Dexie instance that is not blocked (vip Dexie). This was the case also before but then we had to rely on zone state. This change makes it possible to perform non-dexie operations in on.read() callback (such as fetch()), loosing the zone state (PSD) but still have VIP access to the Dexie instance. This makes the code in a on.ready() callback not having to deal with wrapping all non-Dexie calls with Promise.resolve().

