### PR TITLE
Should use Record as type instead Object

### DIFF
--- a/src/public/types/table-hooks.d.ts
+++ b/src/public/types/table-hooks.d.ts
@@ -21,7 +21,7 @@ interface DeletingHookContext<T,Key> {
 interface TableHooks<T=any,TKey=IndexableType> extends DexieEventSet {
   (eventName: 'creating', subscriber: (this: CreatingHookContext<T,TKey>, primKey:TKey, obj:T, transaction:Transaction) => any): void;
   (eventName: 'reading', subscriber: (obj:T) => T | any): void;
-  (eventName: 'updating', subscriber: (this: UpdatingHookContext<T,TKey>, modifications:Object, primKey:TKey, obj:T, transaction:Transaction) => any): void;
+  (eventName: 'updating', subscriber: (this: UpdatingHookContext<T,TKey>, modifications:Record<string,unknown>, primKey:TKey, obj:T, transaction:Transaction) => any): void;
   (eventName: 'deleting', subscriber: (this: DeletingHookContext<T,TKey>, primKey:TKey, obj:T, transaction:Transaction) => any): void;
   creating: DexieEvent;
   reading: DexieEvent;


### PR DESCRIPTION
Refer to the typescript-eslint rule [ban-types](https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/ban-types.md#default-options). Use `Record<string, unknown>` as type instead of `Object` or `object`.