### PR TITLE
Allow gracePeriod and onError options to useDocument()

### DIFF
--- a/libs/dexie-react-hooks/src/useDocument.ts
+++ b/libs/dexie-react-hooks/src/useDocument.ts
@@ -73,7 +73,7 @@ export function useDocument(
         return () => {
           DexieYProvider.release(doc);
           if (onErrorRef.current) {
-            provider.off('error', onErrorRef.current);
+            provider!.off('error', onErrorRef.current);
           }
         };
       } else {


### PR DESCRIPTION
When merging this PR, release a new dexie-react-hooks package and document the new options.

This PR was mainly done to allow attaching an error handler to the DexieYProvider in case writing updates failed for any reason.

However, failing to write updates to dexie should probably be catched globally and not on every single component, since this could be due to quota limit exceeded or instable indexedDB.

So, think also about a solution to catch these types of errors globally. This is not dedicated to Y.js but rather working around indexedDB stability issues for an application. For example, the application might need to show a big warning message that it isn't able to store data. Use StorageManager API to show the quota left and advice user to take action, such as clearing storage.