### PR TITLE
Repro of #1922

### DIFF
--- a/addons/dexie-cloud/test/unit/tests-github-issues.ts
+++ b/addons/dexie-cloud/test/unit/tests-github-issues.ts
@@ -33,39 +33,44 @@ promisedTest('https://github.com/dexie/Dexie.js/issues/1922', async () => {
     requireAuth: { email: 'foo@demo.local', grant_type: 'demo' },
     disableEagerSync: true, // Let us manually sync them
   });
-  await db.open();
-  ok(true, 'DB opened and synced successfully');
-  await db.items1922.clear();
-  ok(true, 'Items cleared successfully');
-  let primKeys = await db.items1922.bulkAdd(
-    [
-      { bookId: 'book1', tags: ['tag1', 'tag2'] },
-      { bookId: 'book2', tags: ['tag2', 'tag3'] },
-    ],
-    { allKeys: true }
-  );
-  await db.cloud.sync();
-  ok(true, 'Items added and synced successfully');
-  await db.items1922.where('tags').equals('tag1').modify({ bookId: 'book3' });
-  let itemsBeforeSync = await db.items1922.toArray();
-  deepEqual(
-    itemsBeforeSync.map(strip(...DEXIE_CLOUD_PROPS)),
-    [
-      { id: primKeys[0], bookId: 'book3', tags: ['tag1', 'tag2'] },
-      { id: primKeys[1], bookId: 'book2', tags: ['tag2', 'tag3'] },
-    ],
-    'Items before sync'
-  );
-  await db.cloud.sync();
-  let itemsAfterSync = await db.items1922.toArray();
-  deepEqual(
-    itemsAfterSync.map(strip(...DEXIE_CLOUD_PROPS)),
-    [
-      { id: primKeys[0], bookId: 'book3', tags: ['tag1', 'tag2'] },
-      { id: primKeys[1], bookId: 'book2', tags: ['tag2', 'tag3'] },
-    ],
-    'Items after sync'
-  );
+  try {
+    await db.open();
+    ok(true, 'DB opened and synced successfully');
+    await db.items1922.clear();
+    ok(true, 'Items cleared successfully');
+    let primKeys = await db.items1922.bulkAdd(
+      [
+        { bookId: 'book1', tags: ['tag1', 'tag2'] },
+        { bookId: 'book2', tags: ['tag2', 'tag3'] },
+      ],
+      { allKeys: true }
+    );
+    await db.cloud.sync();
+    ok(true, 'Items added and synced successfully');
+    await db.items1922.where('tags').equals('tag1').modify({ bookId: 'book3' });
+    let itemsBeforeSync = await db.items1922.toArray();
+    deepEqual(
+      itemsBeforeSync.map(strip(...DEXIE_CLOUD_PROPS)),
+      [
+        { id: primKeys[0], bookId: 'book3', tags: ['tag1', 'tag2'] },
+        { id: primKeys[1], bookId: 'book2', tags: ['tag2', 'tag3'] },
+      ],
+      'Items before sync'
+    );
+    await db.cloud.sync();
+    let itemsAfterSync = await db.items1922.toArray();
+    deepEqual(
+      itemsAfterSync.map(strip(...DEXIE_CLOUD_PROPS)),
+      [
+        { id: primKeys[0], bookId: 'book3', tags: ['tag1', 'tag2'] },
+        { id: primKeys[1], bookId: 'book2', tags: ['tag2', 'tag3'] },
+      ],
+      'Items after sync'
+    );
+  } finally {
+    await db.items1922.clear();
+    await db.cloud.sync();
+  }
 });
 
 /** Dexie issue #2185


### PR DESCRIPTION
This PR is currently failing as it reproduces issue #1922. When the bug is solved in dexie.cloud service, please rerun the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Dexie Cloud test suite with new scenarios covering open/sync/modify/validate flows
  * Added scaffolding for deterministic sync tests and improved data normalization before assertions
  * Standardized transaction callbacks and formatting for clearer, more reliable tests
  * Strengthened assertions and synchronization checks across multiple scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->