### PR TITLE
Fix ES module build for dexie-react-hooks

### DIFF
--- a/libs/dexie-react-hooks/rollup.config.mjs
+++ b/libs/dexie-react-hooks/rollup.config.mjs
@@ -26,7 +26,10 @@ export default {
   }],
   external: ['dexie', 'react', 'react-dom'],
   plugins: [
-    typescript(),
+    typescript({
+      module: 'esnext',
+      target: 'es2022'
+    }),
     nodeResolve({
       browser: true,
       preferBuiltins: false


### PR DESCRIPTION
## Problem
The version `dexie-react-hooks@4.2.2-beta.1` has broken ES module exports due to build configuration issues introduced in PR #2224.

## Root Cause
The `@rollup/plugin-typescript` was upgraded from v8 to v12 in PR #2224. The new version changed its default behavior and now respects the `tsconfig.json` `'module': 'node16'` setting even for ES module outputs.

This caused the `.mjs` file to contain CommonJS syntax:
```javascript
Object.defineProperty(exports, "__esModule", { value: true });
const tslib_1 = require("tslib");
```

Instead of ES module syntax:
```javascript
export { useDocument, useLiveQuery, useObservable, usePermissions };
```

## Solution
Explicitly configure the TypeScript plugin with:
```javascript
typescript({
  module: 'esnext',
  target: 'es2022'
})
```

This ensures `.mjs` files use proper ES module syntax regardless of `tsconfig.json` settings.

## Testing
- ✅ Verified the fix generates correct ES module syntax in `.mjs` files
- ✅ Tested import/build works correctly in Vite React app
- ✅ No breaking changes to existing functionality

Closes #2240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to enhance module transpilation and JavaScript compatibility across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->