### PR TITLE
fix: Handle template strings with leading newlines in schema declaration

### DIFF
--- a/src/classes/version/schema-helpers.ts
+++ b/src/classes/version/schema-helpers.ts
@@ -462,7 +462,16 @@ export function adjustToExistingIndexNames(db: Dexie, schema: DbSchema, idbtrans
 }
 
 export function parseIndexSyntax(primKeyAndIndexes: string): IndexSpec[] {
-  return primKeyAndIndexes.split(',').map((index, indexNum) => {
+  // Filter out empty entries first to handle template strings with leading newlines.
+  // This ensures the first non-empty entry gets indexNum === 0 (primary key).
+  const entries = primKeyAndIndexes.split(',').filter(s => s.trim());
+  
+  // Handle empty string case for backward compatibility (parseIndexSyntax("")[0] should return a spec)
+  if (entries.length === 0) {
+    return [createIndexSpec('', null, false, false, false, false, true, undefined)];
+  }
+
+  return entries.map((index, indexNum) => {
     const typeSplit = index.split(':');
     const type = typeSplit[1]?.trim();
     index = typeSplit[0].trim();


### PR DESCRIPTION
## Problem

Schema declarations using template strings with leading newlines would fail to identify the primary key correctly:

```typescript
db.version(1).stores({
  items: `
    ++id,
    name
  `
});
```

The `split(',')` would produce `['', '    ++id', '    name']` and the empty string would incorrectly get `indexNum === 0` (primary key), causing the actual primary key (`++id`) to not be recognized.

## Solution

Filter empty entries before mapping to ensure the first non-empty entry gets `indexNum === 0`. Also maintains backward compatibility with `parseIndexSyntax('')[0]` which is used internally.

## Changes

- Modified `parseIndexSyntax()` in `schema-helpers.ts` to filter empty entries first
- Added special handling for empty string input (backward compat)
- Added unit test for template string schema declaration

## Testing

Verified manually that:
- Template strings with leading newlines now work correctly
- Normal schema declarations still work
- Empty string input returns expected IndexSpec (backward compat)
- `@` prefix for dexie-cloud is preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema parsing robustness to gracefully handle template strings containing empty or whitespace-only entries and leading newlines, ensuring better compatibility with various formatting styles.

* **Tests**
  * Added test coverage verifying schema parsing with multiline template strings and leading newlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->