### PR TITLE
fix(types): Allow any return type from update/modify callbacks

### DIFF
--- a/src/public/types/collection.d.ts
+++ b/src/public/types/collection.d.ts
@@ -43,6 +43,6 @@ export interface Collection<T=any, TKey=IndexableType, TInsertType=T> {
   until(filter: (value: T) => boolean, includeStopEntry?: boolean): Collection<T, TKey, TInsertType>;
   // Mutating methods
   delete(): PromiseExtended<number>;
-  modify(changeCallback: (obj: T, ctx:{value: TInsertType}) => void | boolean): PromiseExtended<number>;
+  modify(changeCallback: (obj: T, ctx:{value: TInsertType}) => any): PromiseExtended<number>;
   modify(changes: UpdateSpec<TInsertType>): PromiseExtended<number>;
 }

--- a/src/public/types/table.d.ts
+++ b/src/public/types/table.d.ts
@@ -45,7 +45,7 @@ export interface Table<T=any, TKey=any, TInsertType=T> {
   add(item: TInsertType, key?: TKey): PromiseExtended<TKey>;
   update(
     key: TKey | T,
-    changes: UpdateSpec<TInsertType> | ((obj: T, ctx:{value: any, primKey: IndexableType}) => void | boolean)): PromiseExtended<number>;
+    changes: UpdateSpec<TInsertType> | ((obj: T, ctx:{value: any, primKey: IndexableType}) => any)): PromiseExtended<number>;
   upsert(
     key: TKey | T,
     changes: UpdateSpec<TInsertType>): PromiseExtended<boolean>;


### PR DESCRIPTION
## Problem

TypeScript rejects common patterns like:

```typescript
db.friends.update(id, (friend) => ++friend.age)
```

Because the callback return type was defined as `void | boolean`, but `++friend.age` returns `number`.

## Solution

Changed callback return type from `void | boolean` to `any` in:
- `Table.update()`
- `Collection.modify()`

The runtime only checks for `=== false` to cancel the modification, so any other return value is valid.

## Testing

All of these now compile:
- `db.friends.update(id, (friend) => ++friend.age)` - returns number
- `db.friends.update(id, (friend) => { friend.age++; })` - returns void  
- `db.friends.update(id, (friend) => { if (x) return false; })` - returns false to cancel
- `db.friends.toCollection().modify((friend) => ++friend.age)` - Collection.modify too

## Related

Reported in: https://github.com/dexie/dexie-web/pull/10#issuecomment-3898295972

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated callback return type specifications in Collection.modify and Table.update operations. Callbacks were previously restricted to void or boolean return types and can now return any value type. These modifications accommodate a broader range of callback implementations and usage patterns across custom modification and update operations, extending API flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->