### PR TITLE
fix: use `namespace` instead of `module` keyword for TS 6/7 compat

### DIFF
--- a/src/public/index.d.ts
+++ b/src/public/index.d.ts
@@ -39,7 +39,7 @@ interface _Collection<T,TKey> extends Collection<T,TKey> {}
 
 // Besides being the only exported value, let Dexie also be
 // a namespace for types...
-declare module Dexie {
+declare namespace Dexie {
   // The "Dexie.Promise" type.
   type Promise<T=any> = PromiseExtended<T> // Because many samples have been Dexie.Promise.
   // The "Dexie.Table" interface. Same as named exported interface Table.


### PR DESCRIPTION
## Summary

Fixes #2248

TypeScript 6+ (and `tsgo` from `7.0.0-dev.20260221.1`) now errors on non-ambient `declare module Foo {}` declarations ([TS1540](https://github.com/microsoft/TypeScript/pull/62876)), requiring `declare namespace Foo {}` instead.

This PR changes the single occurrence in `src/public/index.d.ts` (line 42):

```diff
-declare module Dexie {
+declare namespace Dexie {
```

The `module` and `namespace` keywords are functionally identical for this use case — this is a purely syntactic change with no runtime or type-level impact.

### Verified

- This is the **only** non-ambient `declare module` in the repo
- Addon files (`Dexie.Syncable`, `Dexie.Observable`, `dexie-cloud`) all use `declare module 'dexie'` (quoted string — ambient module augmentation), which is valid and **unaffected**
- Binary-searched `tsgo` dev builds to confirm the breaking change was introduced in `7.0.0-dev.20260221.1` (Feb 21, 2026)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated TypeScript type declaration structure for improved type system consistency. This change does not affect the public API or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->