### PR TITLE
Avoid unnecessary tracking of connections on Chrome 115+

### DIFF
--- a/src/classes/dexie/dexie-open.ts
+++ b/src/classes/dexie/dexie-open.ts
@@ -111,7 +111,7 @@ export function dexieOpen (db: Dexie) {
           // as well as absurd upgrade version quirk for Safari.
         }
         
-        connections.push(db); // Used for emulating versionchange event on IE/Edge/Safari.
+      if (db._trackConnection) connections.push(db); // Used for BFCache support and emulating versionchange event on older browsers.
         
         idbdb.onversionchange = wrap(ev => {
             state.vcFired = true; // detect implementations that not support versionchange (IE/Edge/Safari)

--- a/src/classes/dexie/dexie.ts
+++ b/src/classes/dexie/dexie.ts
@@ -26,7 +26,7 @@ import Promise, { PSD, globalPSD } from '../../helpers/promise';
 import { extend, override, keys, hasOwn } from '../../functions/utils';
 import Events from '../../helpers/Events';
 import { maxString, connections, READONLY, READWRITE } from '../../globals/constants';
-import { getMaxKey } from '../../functions/quirks';
+import { getMaxKey, isModernChrome } from '../../functions/quirks';
 import { exceptions } from '../../errors';
 import { lowerVersionFirst } from '../version/schema-helpers';
 import { dexieOpen } from './dexie-open';
@@ -77,6 +77,7 @@ export class Dexie implements IDexie {
   _middlewares: {[StackName in keyof DexieStacks]?: Middleware<DexieStacks[StackName]>[]} = {};
   _vip?: boolean;
   _novip: Dexie;// db._novip is to escape to orig db from db.vip.
+  _trackConnection: boolean;
   core: DBCore;
 
   name: string;
@@ -112,6 +113,7 @@ export class Dexie implements IDexie {
     const {
       addons,
     } = options;
+    this._trackConnection = !isModernChrome;
     this._dbSchema = {};
     this._versions = [];
     this._storeNames = [];

--- a/src/functions/quirks.ts
+++ b/src/functions/quirks.ts
@@ -19,3 +19,18 @@ export let getMaxKey = (IdbKeyRange: typeof IDBKeyRange) => {
     return maxString;
   }
 }
+
+export const isModernChromeInternal = (userAgent: string) => {
+  const chromeMatch = userAgent.match(/Chrome\/(\d+)/);
+  return chromeMatch && parseInt(chromeMatch[1], 10) >= 115;
+}
+
+/** 
+ * Chrome 115 allows a page to enter the BFCache with active connections
+ * and transactions, as long as they're not blocking others. Additionally,
+ * it supports the "versionchange" event natively. As a result, there
+ * is no need to track Dexie connections in a global array to support
+ * BFCache or "versionchange" on modern Chrome.
+ */
+export const isModernChrome = typeof navigator !== 'undefined' &&
+  isModernChromeInternal(navigator.userAgent);

--- a/src/public/types/dexie.d.ts
+++ b/src/public/types/dexie.d.ts
@@ -41,6 +41,7 @@ export interface Dexie {
   ) => Transaction;
 
   readonly _novip: Dexie;
+  _trackConnection: boolean;
 
   _dbSchema: DbSchema;
 

--- a/test/tests-all.js
+++ b/test/tests-all.js
@@ -19,4 +19,5 @@ import "./tests-blobs";
 import "./tests-binarykeys";
 import "./tests-live-query";
 import "./tests-rangeset";
+import "./tests-connections.js";
 //import "./tests-performance.js"; Not required. Should make other performance tests separately instead.

--- a/test/tests-connections.js
+++ b/test/tests-connections.js
@@ -1,0 +1,54 @@
+import Dexie from 'dexie';
+import { module, stop, start, asyncTest, ok, equal } from 'QUnit';
+import { spawnedTest } from './dexie-unittest-utils';
+import { isModernChromeInternal } from '../src/functions/quirks';
+
+module("connections", {
+    setup: function () {
+        stop();
+        Dexie.delete("TestDB").then(start);
+    },
+    teardown: function () {
+        stop();
+        Dexie.delete("TestDB").then(start);
+    }
+});
+
+spawnedTest("Dexie connection tracking should respect _trackConnection", function* () {
+    const isChrome115 = typeof navigator !== 'undefined' && 
+        (() => {
+            const m = navigator.userAgent.match(/Chrome\/(\d+)/);
+            return m && parseInt(m[1]) >= 115;
+        })();
+
+    const db = new Dexie("TestDB");
+    db.version(1).stores({foo: 'id'});
+    
+    if (isChrome115) {
+        ok(!db._trackConnection, "In Chrome 115+, _trackConnection should be false by default");
+        const initialConnections = Dexie.connections.length;
+        yield db.open();
+        equal(Dexie.connections.length, initialConnections, "Connection should NOT be added to Dexie.connections in Chrome 115+");
+    } else {
+        ok(db._trackConnection, "In other browsers, _trackConnection should be true by default");
+        const initialConnections = Dexie.connections.length;
+        yield db.open();
+        equal(Dexie.connections.length, initialConnections + 1, "Connection SHOULD be added to Dexie.connections in other browsers");
+        db.close();
+        equal(Dexie.connections.length, initialConnections, "Connection should be removed from Dexie.connections after close");
+    }
+});
+
+spawnedTest("isModernChromeInternal should correctly detect Chrome >= 115", function* () {
+    const isModern = isModernChromeInternal;
+    
+    ok(isModern("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36"), "Chrome 115 detected as modern");
+    ok(isModern("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"), "Chrome 116 detected as modern");
+    ok(isModern("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"), "Chrome 120 detected as modern");
+    ok(isModern("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"), "Edge 120 (Chromium based) detected as modern Chrome");
+    
+    ok(!isModern("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"), "Chrome 114 NOT detected as modern");
+    ok(!isModern("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.0.0 Safari/537.36"), "Chrome 100 NOT detected as modern");
+    ok(!isModern("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15"), "Safari NOT detected as modern Chrome");
+    ok(!isModern("Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0"), "Firefox 115 NOT detected as modern Chrome");
+});


### PR DESCRIPTION
Historically, Dexie tracked Dexie instances in a global "connections" array to emulate "versionchange" events and close connections on pagehide to allow pages to enter BFCache. However, Chrome natively supports "versionchange" and, since version 115, allows pages to enter the BFCache with active connections (see: http://crrev.com/c/4496128). Tracking of connections in a global "connections" array is therefore no longer necessary.

This change disables adding connections to the global "connections" array for Chrome 115+. This is important because if developers forget to call close() on a Dexie instance, it remains in the global array indefinitely. Chromium developers have identified this as a source of significant memory bloat in the browser process (hundreds of MiB in real-world cases). Not tracking connections in the global array prevents that performance issue by default.

Entering BFCache with an active IndexedDB connection is demonstrated here: https://francoisdoray.github.io/web-repros/bfcache-dexie.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced database connection handling with browser-aware optimization for modern Chrome browsers.

* **Tests**
  * Added comprehensive test coverage for connection tracking and browser detection logic across different browser environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->