### PR TITLE
fix(react-hooks): TypeScript-safe React < 19 usePromise

### DIFF
--- a/libs/dexie-react-hooks/src/usePromise.ts
+++ b/libs/dexie-react-hooks/src/usePromise.ts
@@ -1,8 +1,10 @@
 import * as React from 'react';
 
 /** {@link React.use} if supported, else fallback */
+const reactUse = Reflect.get(React, 'use');
+
 export const usePromise: <T>(promise: PromiseLike<T>) => T =
-  React.use ?? fallbackUsePromise;
+  reactUse ?? fallbackUsePromise;
 
 /** Fallback for `React.use` with promise */
 function fallbackUsePromise<T>(promise: PromiseLike<T>): T {


### PR DESCRIPTION
### Summary
- make `usePromise` TypeScript-safe for React < 19 by avoiding direct `React.use` access

### Why
- some TS toolchains can fail on React < 19 with: 
```
./node_modules/dexie-react-hooks/dist/dexie-react-hooks.mjs
Attempted import error: 'use' is not exported from 'react' (imported as 'React').
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal access mechanism for promise handling features to improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->