### PR TITLE
fix(dexie-cloud): graceful fallback when server lacks blob endpoint

### DIFF
--- a/addons/dexie-cloud/src/sync/blobOffloading.ts
+++ b/addons/dexie-cloud/src/sync/blobOffloading.ts
@@ -11,6 +11,10 @@ import { BlobRef, BlobRefOrigType, isBlobRef as isBlobRefFromResolve } from './b
 // Blobs >= 4KB are offloaded to blob storage
 const BLOB_OFFLOAD_THRESHOLD = 4096;
 
+// Cache: once we know the server doesn't support blob storage, skip future uploads.
+// Maps databaseUrl → boolean (true = supported, false = not supported).
+const blobEndpointSupported = new Map<string, boolean>();
+
 // Re-export BlobRef type
 export type { BlobRef, BlobRefOrigType };
 
@@ -101,7 +105,7 @@ export async function uploadBlob(
   databaseUrl: string,
   getCachedAccessToken: () => Promise<string | null>,
   blob: Blob | ArrayBuffer | ArrayBufferView
-): Promise<BlobRef> {
+): Promise<BlobRef | null> {
   const accessToken = await getCachedAccessToken();
   if (!accessToken) {
     throw new Error('Failed to load access token for blob upload');
@@ -151,6 +155,11 @@ export async function uploadBlob(
   });
   
   if (!response.ok) {
+    if (response.status === 404 || response.status === 405) {
+      // Server doesn't support blob storage endpoint — fall back to inline storage.
+      // This happens when a new client connects to an older server (pre-3.0).
+      return null;
+    }
     throw new Error(`Failed to upload blob: ${response.status} ${response.statusText}`);
   }
   
@@ -198,8 +207,19 @@ export async function offloadBlobs(
   
   // Check if this is a blob that should be offloaded
   if (shouldOffloadBlob(obj)) {
+    if (blobEndpointSupported.get(databaseUrl) === false) {
+      // Server known to not support blob storage — keep inline
+      return obj;
+    }
+    const blobRef = await uploadBlob(databaseUrl, getCachedAccessToken, obj);
+    if (blobRef === null) {
+      // Server doesn't support blob storage — keep original inline
+      blobEndpointSupported.set(databaseUrl, false);
+      return obj;
+    }
+    blobEndpointSupported.set(databaseUrl, true);
     dirtyFlag.dirty = true;
-    return uploadBlob(databaseUrl, getCachedAccessToken, obj);
+    return blobRef;
   }
   
   if (typeof obj !== 'object') {


### PR DESCRIPTION
## Problem

When a new dexie-cloud-addon (4.4.0) connects to an older server (pre-3.0) that doesn't have the `/blob/` endpoint, blob uploads fail with 404, causing the entire sync to break.

**Scenario:** On-prem customers update client libraries before upgrading their server.

## Fix

- `uploadBlob()` returns `null` on 404/405 instead of throwing
- `offloadBlobs()` keeps the original blob inline when upload returns null (pre-4.4.0 behavior)
- Result is cached per `databaseUrl` so subsequent syncs skip the upload attempt entirely

## Testing

- Build passes (`pnpm build` clean)
- No existing behavior changed — blobs are still offloaded when server supports it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent caching to remember server blob storage support, reducing unnecessary upload attempts.

* **Bug Fixes**
  * Improved handling for servers without blob storage support by gracefully falling back to inline storage instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->