### PR TITLE
fix(cloud): enforce minimum maxStringLength of 100

### DIFF
--- a/addons/dexie-cloud/src/DexieCloudOptions.ts
+++ b/addons/dexie-cloud/src/DexieCloudOptions.ts
@@ -94,6 +94,8 @@ export interface DexieCloudOptions {
    * reducing sync payload size. The original string is kept intact in IndexedDB.
    * 
    * Set to `Infinity` to disable string offloading.
+   * Minimum value is 100 to prevent accidental offloading of primary keys.
+   * Maximum value is 32768 (server limit).
    * 
    * @default 32768
    */

--- a/addons/dexie-cloud/src/dexie-cloud-client.ts
+++ b/addons/dexie-cloud/src/dexie-cloud-client.ts
@@ -165,17 +165,20 @@ export function dexieCloud(dexie: Dexie) {
     roles: getGlobalRolesObservable(dexie),
     configure(options: DexieCloudOptions) {
       // Validate maxStringLength — Infinity disables offloading, otherwise must be
-      // a finite positive number not exceeding the server limit (32768).
+      // a finite number between 100 and the server limit (32768).
+      // Minimum 100 prevents accidental offloading of primary keys and short strings
+      // that would break sync.
+      const MIN_STRING_LENGTH = 100;
       const MAX_SERVER_STRING_LENGTH = 32768;
       if (
         options.maxStringLength !== undefined &&
         options.maxStringLength !== Infinity &&
         (!Number.isFinite(options.maxStringLength) ||
-          options.maxStringLength < 0 ||
+          options.maxStringLength < MIN_STRING_LENGTH ||
           options.maxStringLength > MAX_SERVER_STRING_LENGTH)
       ) {
         throw new Error(
-          `maxStringLength must be Infinity or a finite number in [0, ${MAX_SERVER_STRING_LENGTH}]. Got: ${options.maxStringLength}`
+          `maxStringLength must be Infinity or a finite number in [${MIN_STRING_LENGTH}, ${MAX_SERVER_STRING_LENGTH}]. Got: ${options.maxStringLength}`
         );
       }
       options = dexie.cloud.options = { ...dexie.cloud.options, ...options };


### PR DESCRIPTION
## Problem
Setting `maxStringLength` to a very low value (e.g. 10) could cause primary keys and other short critical strings to be offloaded as blobs, breaking sync entirely.

## Solution
Enforce a minimum value of 100 for `maxStringLength`. The valid range is now `[100, 32768]` or `Infinity` (to disable string offloading).

Throws a clear error on `db.cloud.configure()` if the value is below 100:
```
maxStringLength must be Infinity or a finite number in [100, 32768]. Got: 10
```

## Changes
- `dexie-cloud-client.ts`: Changed minimum from 0 to 100
- `DexieCloudOptions.ts`: Updated JSDoc to document min/max range

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added constraint documentation for string length configuration limits, specifying minimum and maximum allowed values to prevent misconfiguration.

* **Bug Fixes**
  * Tightened validation for string length configuration to enforce range constraints, providing clearer error messages for invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->