### PR TITLE
fix(dexie-cloud): use WebSocket protocol v3 for blob offloading support

### DIFF
--- a/addons/dexie-cloud/src/WSObservable.ts
+++ b/addons/dexie-cloud/src/WSObservable.ts
@@ -283,7 +283,7 @@ export class WSConnection extends Subscription {
     wsUrl.protocol = wsUrl.protocol === 'http:' ? 'ws' : 'wss';
     const searchParams = new URLSearchParams();
     if (this.subscriber.closed) return;
-    searchParams.set('v', '2');
+    searchParams.set('v', '3'); // v3 = supports BlobRef (blob offloading)
     if (this.rev) searchParams.set('rev', this.rev);
     if (this.yrev) searchParams.set('yrev', this.yrev);
     searchParams.set('realmsHash', this.realmSetHash);


### PR DESCRIPTION
WebSocket connection was hardcoded to `v: 2`, causing the server to unnecessarily resolve BlobRefs inline for v3-capable clients (via PR dexie/dexie-cloud#109).

HTTP sync already sends `v: 3` (in `syncWithServer.ts`). This aligns WebSocket to match.

**Change:** `searchParams.set('v', '2')` → `searchParams.set('v', '3')` in `WSObservable.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WebSocket protocol version for improved backend compatibility and communication efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->