### PR TITLE
fix: resolve liveQuery race condition where storagemutated events are missed (#2270)

### DIFF
--- a/src/live-query/live-query.ts
+++ b/src/live-query/live-query.ts
@@ -1,4 +1,9 @@
-import { _global, isAsyncFunction, keys, objectIsEmpty } from '../functions/utils';
+import {
+  _global,
+  isAsyncFunction,
+  keys,
+  objectIsEmpty,
+} from '../functions/utils';
 import {
   globalEvents,
   DEXIE_STORAGE_MUTATED_EVENT_NAME,
@@ -71,7 +76,8 @@ export function liveQuery<T>(querier: () => T | Promise<T>): IObservable<T> {
         if (closed) return;
         closed = true;
         if (abortController) abortController.abort();
-        if (startedListening) globalEvents.storagemutated.unsubscribe(mutationListener);
+        if (startedListening)
+          globalEvents.storagemutated.unsubscribe(mutationListener);
       },
     };
 
@@ -95,7 +101,8 @@ export function liveQuery<T>(querier: () => T | Promise<T>): IObservable<T> {
     const _doQuery = () => {
       if (
         closed || // closed - don't run!
-        !domDeps.indexedDB) // SSR in sveltekit, nextjs etc
+        !domDeps.indexedDB
+      ) // SSR in sveltekit, nextjs etc
       {
         return;
       }
@@ -108,14 +115,14 @@ export function liveQuery<T>(querier: () => T | Promise<T>): IObservable<T> {
       //    (they will remain in memory for a short time and if noone needs them again, they will eventually be freed up)
       if (abortController) abortController.abort(); // Cancel previous query. Last query will be cancelled on unsubscribe().
       abortController = new AbortController();
-      
+
       const ctx: LiveQueryContext = {
         subscr,
         signal: abortController.signal,
         requery: doQuery,
         querier,
-        trans: null // Make the scope transactionless (don't reuse transaction from outer scope of the caller of subscribe())
-      }
+        trans: null, // Make the scope transactionless (don't reuse transaction from outer scope of the caller of subscribe())
+      };
       const ret = execute(ctx);
 
       // Register mutation listener before the async gap so that storagemutated
@@ -154,17 +161,20 @@ export function liveQuery<T>(querier: () => T | Promise<T>): IObservable<T> {
               doQuery();
             } else {
               accumMuts = {};
-              execInGlobalContext(()=>!closed && observer.next && observer.next(result));
+              execInGlobalContext(
+                () => !closed && observer.next && observer.next(result)
+              );
             }
           }
         },
         (err) => {
           hasValue = false;
           if (!['DatabaseClosedError', 'AbortError'].includes(err?.name)) {
-            if (!closed) execInGlobalContext(()=>{
-              if (closed) return;
-              observer.error && observer.error(err);
-            });
+            if (!closed)
+              execInGlobalContext(() => {
+                if (closed) return;
+                observer.error && observer.error(err);
+              });
           }
         }
       );


### PR DESCRIPTION
## Problem

When a long rw transaction (e.g. Dexie Cloud initial sync with 21K+ objects) blocks a liveQuery's readonly transaction, the storagemutated event fires before the mutation listener is registered. The liveQuery permanently misses the update and shows stale/empty data.

Reported and diagnosed by @bennie-forss in #2270 with a detailed timeline and A/B test results.

## Root Cause

In _doQuery() in live-query.ts:
1. mutationListener is registered after the async query resolves (inside .then())
2. If a storagemutated event fires during the async gap (while the query is blocked by an rw tx), the event is permanently lost

## Fix

Two changes:

1. **Register mutationListener before the async gap** — immediately after execute(ctx), so events are captured in accumMuts while the query is blocked. shouldNotify() safely returns false when currentObs is empty.

2. **Re-check shouldNotify() after updating currentObs** — mutations that arrived during the query might overlap with the NEW observation set but not the old (empty) one.

## Test Results

- **305/305 karma tests pass** (ChromeNoSandbox)
- A/B test by @bennie-forss: patched = **0ms** skeleton gap vs unpatched = **~30s** skeleton gap after sync

## Affected Scenarios

- Initial sync at login (always affected)
- Reconnection after offline (high risk with large batches)
- Navigation during active sync (new liveQueries created)
- Shared realms with active collaborators

Resolves #2270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mutation listener registration timing to prevent missing data changes during query execution

* **Refactor**
  * Optimized query update logic to properly detect when mutations require result refresh
  * Enhanced notification control flow for more reliable live query updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->