### PR TITLE
fix(dexie-cloud-addon): make options argument optional in Table.newId()

### DIFF
--- a/addons/dexie-cloud/src/extend-dexie-interface.ts
+++ b/addons/dexie-cloud/src/extend-dexie-interface.ts
@@ -25,7 +25,7 @@ declare module 'dexie' {
   }
 
   interface Table {
-    newId(options: NewIdOptions): string;
+    newId(options?: NewIdOptions): string;
     idPrefix(): string;
   }
 


### PR DESCRIPTION
## Summary

`Table.prototype.newId` already handles being called without arguments — the implementation uses destructuring with a default: `{ colocateWith }: NewIdOptions = {}`. However, the TypeScript interface declared the parameter as required, causing a compile error when calling `db.myTable.newId()` without arguments.

## Change

```ts
// Before
newId(options: NewIdOptions): string;

// After
newId(options?: NewIdOptions): string;
```

No runtime changes. One character in the type declaration.

## Motivation

`colocateWith` is an advanced sharding concern only relevant when scaling across realm shards. For the vast majority of use cases, `db.myTable.newId()` with no arguments is the natural API for pre-generating a globally unique ID before inserting an object.

## Testing

- Build passes (`pnpm build` in `addons/dexie-cloud`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ID generation method now accepts an optional configuration parameter instead of requiring it, providing greater flexibility in usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->