### PR TITLE
fix(dexie-cloud): fix 'Illegal invocation' in blobResolveMiddleware cursor proxy

### DIFF
--- a/addons/dexie-cloud/src/middlewares/blobResolveMiddleware.ts
+++ b/addons/dexie-cloud/src/middlewares/blobResolveMiddleware.ts
@@ -201,6 +201,29 @@ function createBlobResolvingCursor(
 ): DBCoreCursor {
   // Create wrapped cursor using Object.create() - inherits everything
   const wrappedCursor = Object.create(cursor, {
+    // key and primaryKey must be overridden with explicit getters that delegate to the
+    // original cursor via the closed-over reference.
+    //
+    // Without this, accessing .key or .primaryKey on the wrappedCursor would fall through
+    // the prototype chain and invoke the native IDBCursorWithValue getter with `this` set
+    // to wrappedCursor (a plain object), causing "TypeError: Illegal invocation".
+    //
+    // This matters specifically when:
+    //   1. The query uses the primary key index (observability middleware does NOT wrap the
+    //      cursor for primary key queries, so no safe intermediate getter exists), OR
+    //   2. Virtual index wrapping is not active (also skips cursor wrapping).
+    key: {
+      get() {
+        return cursor.key;
+      },
+      enumerable: true,
+    },
+    primaryKey: {
+      get() {
+        return cursor.primaryKey;
+      },
+      enumerable: true,
+    },
     value: {
       value: cursor.value,
       enumerable: true,


### PR DESCRIPTION
## Problem

`createBlobResolvingCursor()` in `blobResolveMiddleware` wraps the IDB cursor via `Object.create(cursor, { value, start })` but did not override `key` or `primaryKey`. Accessing these properties on the wrapped cursor falls through the prototype chain to the native `IDBCursorWithValue` getters, which require `this` to be the actual native IDB cursor object. Since `this` is a plain proxy object, the browser throws:

```
TypeError: Illegal invocation
    at IDBCursorWithValue.get [as key/primaryKey]
    at dexie-cloud-addon.js:...
```

**Why does this happen?** The `observabilityMiddleware` (level 0) only wraps cursors for **secondary index** queries — not primary key queries. For primary key queries, blobResolve (level 2) receives the cursor with no intermediate `key`/`primaryKey` getter override, so property lookup hits the native IDB getter directly.

This is a regression triggered by the level change in #2268 (moving blobResolve above the cache). At level `-2` (below observability), blobResolve always received cursors already wrapped by observability. At level `2` (above observability), blobResolve can receive unwrapped native IDB cursors on primary key paths.

## Fix

Add explicit `key` and `primaryKey` getters to the `Object.create()` property descriptor map. They close over the original cursor reference, matching the pattern used by Dexie's own `ProxyCursor` helper and the `observabilityMiddleware`/`virtual-index-middleware`:

```ts
key: {
  get() { return cursor.key; },
  enumerable: true,
},
primaryKey: {
  get() { return cursor.primaryKey; },
  enumerable: true,
},
```

## What's NOT changed

- `level: 2` is intentionally kept (set in #2268 so cached blob refs get resolved — reverting it would break cache invalidation for blob values).
- No behavioral change for `value` or `start` handling.

## Testing

Build passes (`pnpm build`), unit tests pass (`npm test` in dexie-cloud-common), CodeRabbit: no findings.

Fixes: bug reported in Discord where app crashed on load with 'Illegal invocation' on dexie-cloud-addon 4.4.6–4.4.9 in Chrome on primary-key cursor queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor operation errors that occurred in specific query contexts, resolving "Illegal invocation" TypeErrors during certain data retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->