### PR TITLE
fix(dexie-cloud-addon): add .key/.primaryKey getters to createBlobResolvingCursor (fixes cursor crash)

### DIFF
--- a/addons/dexie-cloud/package.json
+++ b/addons/dexie-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-cloud-addon",
-  "version": "4.4.9",
+  "version": "4.4.10",
   "description": "Dexie addon that syncs with to Dexie Cloud",
   "type": "module",
   "module": "dist/modern/dexie-cloud-addon.js",

--- a/addons/dexie-cloud/src/middlewares/blobResolveMiddleware.ts
+++ b/addons/dexie-cloud/src/middlewares/blobResolveMiddleware.ts
@@ -199,8 +199,20 @@ function createBlobResolvingCursor(
   blobSavingQueue: BlobSavingQueue,
   db: DexieCloudDB
 ): DBCoreCursor {
-  // Create wrapped cursor using Object.create() - inherits everything
+  // Create wrapped cursor using Object.create() - inherits everything.
+  // Important: .key and .primaryKey must be explicitly overridden with
+  // closure-based getters to prevent native IDBCursorWithValue getters from
+  // being reached through the prototype chain with a wrong `this`, which
+  // throws "Illegal invocation" in Chrome 146+.
   const wrappedCursor = Object.create(cursor, {
+    key: {
+      get() { return cursor.key; },
+      configurable: true,
+    },
+    primaryKey: {
+      get() { return cursor.primaryKey; },
+      configurable: true,
+    },
     value: {
       value: cursor.value,
       enumerable: true,


### PR DESCRIPTION
## Problem

`createBlobResolvingCursor()` wraps cursors via `Object.create(cursor, ...)` but only overrides `.value` and `.start` — not `.key` or `.primaryKey`. When these properties are accessed, the prototype chain eventually reaches the native `IDBCursorWithValue` getter with `this` pointing to the wrapper object, causing `TypeError: Illegal invocation`.

All other cursor wrappers in Dexie core (`virtualIndexMiddleware`, liveQuery tracking) already override `.key` and `.primaryKey` correctly. This was the missing case.

## Fix

Add closure-based `.key` and `.primaryKey` getters to the `Object.create()` descriptor in `createBlobResolvingCursor()`:

```typescript
key: { get() { return cursor.key; }, configurable: true },
primaryKey: { get() { return cursor.primaryKey; }, configurable: true },
```

## Version bump

dexie-cloud-addon: 4.4.9 → 4.4.10

## References

Fixes #2292
Reported by ToToDo team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed cursor property access handling to ensure compatibility with Chrome 146+.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->