### PR TITLE
fix: Collection.sortBy() throws on frozen arrays in immutable cache mode

### DIFF
--- a/src/classes/collection/collection.ts
+++ b/src/classes/collection/collection.ts
@@ -195,7 +195,7 @@ export class Collection implements ICollection {
       return cmp(aVal, bVal) * order;
     }
     return this.toArray(function (a) {
-      return a.sort(sorter);
+      return a.slice().sort(sorter);
     }).then(cb);
   }
 


### PR DESCRIPTION
## Problem

When using `cacheMode: 'immutable'`, `toArray()` returns frozen arrays. Calling `.sort()` directly on a frozen array throws:

```
TypeError: Cannot assign to read only property '0' of object '[object Array]'
```

## Fix

Use `.slice().sort()` to sort on a copy rather than mutating the original frozen array.

## Fixes

Fixes #2157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where sorting operations would mutate the original array; the original data is now preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->