### PR TITLE
fix(webkit): retry tempTransaction on 'Cannot inject key into script value' UnknownError

### DIFF
--- a/src/classes/dexie/transaction-helpers.ts
+++ b/src/classes/dexie/transaction-helpers.ts
@@ -145,9 +145,9 @@ export function enterTransactionScope(
         return trans._completion.then(() => x);
       })
       .catch((e) => {
-        trans._reject(e); // Yes, above then-handler were maybe not called because of an unhandled rejection in scopeFunc!
         // Workaround for WebKit "Cannot inject key into script value" UnknownError.
         // Only retry root transactions (not sub-transactions) since sub-transactions share parent's IDBTransaction.
+        // Don't reject the transaction if we're going to retry — let the retry handle it.
         // https://github.com/dexie/Dexie.js/issues/2296
         if (
           !parentTransaction &&
@@ -174,6 +174,7 @@ export function enterTransactionScope(
             )
           );
         }
+        trans._reject(e); // Yes, above then-handler were maybe not called because of an unhandled rejection in scopeFunc!
         return rejection(e);
       });
   });

--- a/src/classes/dexie/transaction-helpers.ts
+++ b/src/classes/dexie/transaction-helpers.ts
@@ -12,6 +12,21 @@ import Promise, {
   incrementExpectedAwaits,
 } from '../../helpers/promise';
 
+/** Detect the WebKit "Cannot inject key into script value" UnknownError.
+ * Same helper used in temp-transaction.ts for tempTransaction retries.
+ * https://github.com/dexie/Dexie.js/issues/2296
+ */
+function isWebKitInjectKeyError(ex: any): boolean {
+  return (
+    ex?.name === 'UnknownError' &&
+    typeof ex?.message === 'string' &&
+    ex.message.includes('inject key')
+  );
+}
+
+const WEBKIT_INJECT_KEY_MAX_RETRIES = 7;
+const WEBKIT_INJECT_KEY_BASE_DELAY_MS = 100;
+
 export function extractTransactionArgs(
   mode: TransactionMode,
   _tableArgs_,
@@ -35,7 +50,8 @@ export function enterTransactionScope(
   mode: IDBTransactionMode,
   storeNames: string[],
   parentTransaction: Transaction | undefined,
-  scopeFunc: () => PromiseLike<any> | any
+  scopeFunc: () => PromiseLike<any> | any,
+  _webkitRetry = 0
 ) {
   return Promise.resolve().then(() => {
     // Keep a pointer to last non-transactional PSD to use if someone calls Dexie.ignoreTransaction().
@@ -130,6 +146,34 @@ export function enterTransactionScope(
       })
       .catch((e) => {
         trans._reject(e); // Yes, above then-handler were maybe not called because of an unhandled rejection in scopeFunc!
+        // Workaround for WebKit "Cannot inject key into script value" UnknownError.
+        // Only retry root transactions (not sub-transactions) since sub-transactions share parent's IDBTransaction.
+        // https://github.com/dexie/Dexie.js/issues/2296
+        if (
+          !parentTransaction &&
+          isWebKitInjectKeyError(e) &&
+          _webkitRetry < WEBKIT_INJECT_KEY_MAX_RETRIES
+        ) {
+          const delay =
+            WEBKIT_INJECT_KEY_BASE_DELAY_MS * Math.pow(1.5, _webkitRetry);
+          if (_webkitRetry === 0) {
+            console.warn(
+              'Dexie: WebKit "Cannot inject key" workaround — retrying transaction'
+            );
+          }
+          return new Promise<void>((resolve) =>
+            setTimeout(resolve, delay)
+          ).then(() =>
+            enterTransactionScope(
+              db,
+              mode,
+              storeNames,
+              parentTransaction,
+              scopeFunc,
+              _webkitRetry + 1
+            )
+          );
+        }
         return rejection(e);
       });
   });

--- a/src/functions/temp-transaction.ts
+++ b/src/functions/temp-transaction.ts
@@ -21,7 +21,7 @@ function isWebKitInjectKeyError(ex: any): boolean {
   );
 }
 
-const WEBKIT_INJECT_KEY_MAX_RETRIES = 20;
+const WEBKIT_INJECT_KEY_MAX_RETRIES = 7;
 const WEBKIT_INJECT_KEY_BASE_DELAY_MS = 100;
 
 /* Generate a temporary transaction when db operations are done outside a transaction scope.

--- a/src/functions/temp-transaction.ts
+++ b/src/functions/temp-transaction.ts
@@ -5,13 +5,33 @@ import { nop } from './chaining-functions';
 import { Transaction } from '../classes/transaction';
 import { Dexie } from '../classes/dexie';
 
+/** Detect the WebKit "Cannot inject key into script value" UnknownError.
+ *
+ * This is a transient WebKit/Safari bug triggered on cold start or after
+ * wake-from-background. The transaction itself is valid — retrying after
+ * a short delay resolves it in practice.
+ *
+ * https://github.com/dexie/Dexie.js/issues/2296
+ */
+function isWebKitInjectKeyError(ex: any): boolean {
+  return (
+    ex?.name === 'UnknownError' &&
+    typeof ex?.message === 'string' &&
+    ex.message.includes('inject key')
+  );
+}
+
+const WEBKIT_INJECT_KEY_MAX_RETRIES = 20;
+const WEBKIT_INJECT_KEY_BASE_DELAY_MS = 100;
+
 /* Generate a temporary transaction when db operations are done outside a transaction scope.
  */
 export function tempTransaction(
   db: Dexie,
   mode: IDBTransactionMode,
   storeNames: string[],
-  fn: (resolve, reject, trans: Transaction) => any
+  fn: (resolve, reject, trans: Transaction) => any,
+  _webkitRetry = 0
 ) {
   // Last argument is "writeLocked". But this doesnt apply to oneshot direct db operations, so we ignore it.
   if (!db.idbdb || (!db._state.openComplete && !PSD.letThrough && !db._vip)) {
@@ -71,6 +91,29 @@ export function tempTransaction(
         return mode === 'readonly'
           ? result
           : trans._completion.then(() => result);
+      })
+      .catch((ex) => {
+        // Workaround for WebKit "Cannot inject key into script value" UnknownError.
+        // This is a transient Safari/WebKit bug that occurs on cold start or after
+        // wake-from-background. Retrying the transaction with exponential backoff resolves it.
+        // https://github.com/dexie/Dexie.js/issues/2296
+        if (
+          isWebKitInjectKeyError(ex) &&
+          _webkitRetry < WEBKIT_INJECT_KEY_MAX_RETRIES
+        ) {
+          const delay =
+            WEBKIT_INJECT_KEY_BASE_DELAY_MS * Math.pow(1.5, _webkitRetry);
+          if (_webkitRetry === 0) {
+            console.warn(
+              'Dexie: WebKit "Cannot inject key" workaround — retrying transaction'
+            );
+          }
+          return new Promise<void>((resolve) => setTimeout(resolve, delay)).then(
+            () =>
+              tempTransaction(db, mode, storeNames, fn, _webkitRetry + 1)
+          );
+        }
+        return rejection(ex);
       }); /*.catch(err => { // Don't do this as of now. If would affect bulk- and modify methods in a way that could be more intuitive. But wait! Maybe change in next major.
           trans._reject(err);
           return rejection(err);


### PR DESCRIPTION
## Problem

Safari/WebKit throws `UnknownError: Cannot inject key into script value` on certain iOS versions when Dexie performs `put()`/`add()` operations. This appears to be a transient WebKit timing issue triggered on cold start or after wake-from-background — the WebKit IndexedDB engine is not yet fully initialized.

- Reported by user in Dexie Discord #general
- GitHub issue: https://github.com/dexie/Dexie.js/issues/2296
- Only affects Safari/WebKit — Chrome on iOS is not affected

## Fix

In `tempTransaction()`, catch `UnknownError` with message containing `'inject key'` and retry the transaction with exponential backoff (100ms base, 1.5x multiplier, max 20 retries). The DB is **not** reopened — just the transaction is retried.

```
Retry schedule: 100ms, 150ms, 225ms, 337ms, ... (up to 20 retries)
Max total wait: ~30 seconds before giving up
```

A `console.warn` is emitted on the first retry to aid debugging.

## Testing

Needs testing on affected iOS Safari version. @markfilius has offered to test a canary build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction reliability in WebKit browsers (Safari) by automatically retrying transient “inject key” UnknownError occurrences.
  * Retries employ exponential backoff with a capped number of attempts to avoid infinite loops.
  * Emits a one-time console warning on the first retry; if retries are exhausted the original error is surfaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->